### PR TITLE
Methods to control how focus moves among widgets.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -142,6 +142,13 @@ Executable buttons
   MainIs: buttons.ml
   BuildDepends: lambda-term
 
+Executable focus
+  Path: examples
+  Install: false
+  CompiledObject: best
+  MainIs: focus.ml
+  BuildDepends: lambda-term
+
 Executable checkbuttons
   Path: examples
   Install: false

--- a/examples/focus.ml
+++ b/examples/focus.ml
@@ -45,12 +45,17 @@ let main () =
     through the 'glue' and hit exit.
 
     We can fix this two ways.  In the "set" mode when 'top' is focussed and down is 
-    pressed we jump to 'left'.  In glue mode when we search down though the glue 
-    widget it points to the 'right' button and we jump there. *)
+    pressed we jump to 'left'.  In "glue" mode when we search down though the 'glue' 
+    widget it points to the 'right' button and we jump there. 
+    
+    Finally, in "error" mode an exception is raised as focus is set to a widget with 
+    can_focus=false.
+    *)
   begin
     match mode with
     | "set" -> top#set_focus { top#focus with LTerm_geom.down = Some(left :> t) }
     | "glue" -> glue#set_focus { glue#focus with LTerm_geom.down = Some(right :> t) }
+    | "error" -> top#set_focus { top#focus with LTerm_geom.left = Some(glue :> t) }
     | _ -> ()
   end;
 

--- a/examples/focus.ml
+++ b/examples/focus.ml
@@ -49,8 +49,8 @@ let main () =
     widget it points to the 'right' button and we jump there. *)
   begin
     match mode with
-    | "set" -> top#set_focus ~down:(left :> t) ()
-    | "glue" -> glue#set_focus ~down:(right :> t) ()
+    | "set" -> top#set_focus { top#focus with LTerm_geom.down = Some(left :> t) }
+    | "glue" -> glue#set_focus { glue#focus with LTerm_geom.down = Some(right :> t) }
     | _ -> ()
   end;
 

--- a/examples/focus.ml
+++ b/examples/focus.ml
@@ -1,0 +1,64 @@
+(*
+ * focus.ml
+ * ----------
+ * Copyright : (c) 2016, Andy Ray <andy.ray@ujamjar.com>
+ * Licence   : BSD3
+ *
+ * This file is a part of Lambda-Term.
+ *)
+open Lwt
+open LTerm_widget
+
+let mode = try Sys.argv.(1) with _ -> "none"
+
+let main () = 
+  let waiter, wakener = wait () in
+  
+  let vbox = new vbox in
+
+  let top = new button mode in
+
+  let leftright = new hbox in
+  let left = new button "left" in
+  let right = new button "right" in
+  let glue = new t "glue" in
+  leftright#add ~expand:false left;
+  leftright#add glue;
+  leftright#add ~expand:false right;
+
+  let exit = new button "exit" in
+  exit#on_click (wakeup wakener);
+
+  vbox#add top;
+  vbox#add ~expand:false leftright;
+  vbox#add ~expand:false exit;
+
+  (* we have a layout like
+
+    [      top        ]
+    [l][...........][r]
+    [      exit       ]
+
+    Focus will start in 'top'.  With no focus specifications when we press down
+    focus will move to exit.  There's no way to get to the 'left'/'right' buttons.
+    This is because lambda-term will search in a line down from the centre of top,
+    through the 'glue' and hit exit.
+
+    We can fix this two ways.  In the "set" mode when 'top' is focussed and down is 
+    pressed we jump to 'left'.  In glue mode when we search down though the glue 
+    widget it points to the 'right' button and we jump there. *)
+  begin
+    match mode with
+    | "set" -> top#set_focus ~down:(left :> t) ()
+    | "glue" -> glue#set_focus ~down:(right :> t) ()
+    | _ -> ()
+  end;
+
+  Lazy.force LTerm.stdout
+  >>= fun term ->
+  run term vbox waiter
+
+let () = Lwt_main.run (main ())
+
+
+

--- a/src/lTerm_geom.ml
+++ b/src/lTerm_geom.ml
@@ -57,3 +57,11 @@ type vert_alignment =
   | V_align_top
   | V_align_center
   | V_align_bottom
+
+type 'a directions = {
+  left : 'a;
+  right : 'a;
+  up : 'a;
+  down : 'a;
+}
+

--- a/src/lTerm_geom.mli
+++ b/src/lTerm_geom.mli
@@ -63,3 +63,12 @@ type vert_alignment =
   | V_align_top
   | V_align_center
   | V_align_bottom
+
+(** Movement directions. *)
+type 'a directions = {
+  left : 'a;
+  right : 'a;
+  up : 'a;
+  down : 'a;
+}
+

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -33,6 +33,13 @@ class t : string -> object
   method can_focus : bool
     (** Whether the widget can receive the focus or not. *)
 
+  method focus : (t option * t option * t option * t option) option
+    (** Specify a target widget to the left, right, up and/or down 
+        when changing focus. *)
+
+  method set_focus : ?left:t -> ?right:t -> ?up:t -> ?down:t -> unit -> unit
+    (** Sets the target widgets when changing focus. *)
+
   method queue_draw : unit
     (** Enqueue a redraw operation. If the widget has a parent, this
         is the same as calling the {!queue_draw} method of the parent,

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -33,11 +33,11 @@ class t : string -> object
   method can_focus : bool
     (** Whether the widget can receive the focus or not. *)
 
-  method focus : (t option * t option * t option * t option) option
+  method focus : t option LTerm_geom.directions
     (** Specify a target widget to the left, right, up and/or down 
         when changing focus. *)
 
-  method set_focus : ?left:t -> ?right:t -> ?up:t -> ?down:t -> unit -> unit
+  method set_focus : t option LTerm_geom.directions -> unit
     (** Sets the target widgets when changing focus. *)
 
   method queue_draw : unit

--- a/src/widget_impl/lTerm_toplevel_impl.ml
+++ b/src/widget_impl/lTerm_toplevel_impl.ml
@@ -20,14 +20,11 @@ class t = LTerm_widget_base_impl.t
 *)
 let get_focus x dir = 
   let f = function None -> `none | Some(x) -> `set_focus(x) in
-  match x with 
-  | None -> `none
-  | Some(left,right,up,down) ->
-    match dir with
-    | `left -> f left
-    | `right -> f right
-    | `up -> f up
-    | `down -> f down
+  match dir with
+  | `left -> f x.left
+  | `right -> f x.right
+  | `up -> f x.up
+  | `down -> f x.down
 
 let make_widget_matrix root dir =
   let { rows; cols } = LTerm_geom.size_of_rect root#allocation in
@@ -44,7 +41,7 @@ let make_widget_matrix root dir =
     in
     if widget#can_focus then begin
       set widget#allocation (`can_focus widget)
-    end else if widget#focus <> None then begin
+    end else begin
       set widget#allocation (get_focus widget#focus dir)
     end;
     List.iter loop widget#children

--- a/src/widget_impl/lTerm_toplevel_impl.ml
+++ b/src/widget_impl/lTerm_toplevel_impl.ml
@@ -3,17 +3,49 @@ open LTerm_key
 
 class t = LTerm_widget_base_impl.t
 
-let make_widget_matrix root =
+(* About focus; widgets may specify an optional target widget in each direction.  
+   The focus specification is intepreted in two ways based on can_focus.
+
+   can_focus=true
+
+      If the currently focussed widget has a focus specification in the required
+      direction that widget is jumped to.  Otherwise a search is performed.
+
+   can_focus=false
+
+      Widgets with can_focus=false will never be the current focus, however, 
+      they can take part in search for a widget.  When we search over such
+      a widget, if it has an appropriate focus specification then we jump
+      there.
+*)
+let get_focus x dir = 
+  let f = function None -> `none | Some(x) -> `set_focus(x) in
+  match x with 
+  | None -> `none
+  | Some(left,right,up,down) ->
+    match dir with
+    | `left -> f left
+    | `right -> f right
+    | `up -> f up
+    | `down -> f down
+
+let make_widget_matrix root dir =
   let { rows; cols } = LTerm_geom.size_of_rect root#allocation in
-  let m = Array.make_matrix rows cols None in
+  let m = Array.make_matrix rows cols `none in
   let rec loop widget =
-    if widget#can_focus then begin
-      let rect = widget#allocation in
-      for r = rect.row1 to rect.row2 - 1 do
-        for c = rect.col1 to rect.col2 - 1 do
-          m.(r).(c) <- Some widget
+    let set rect widget = 
+      if widget <> `none then begin
+        for r = rect.row1 to rect.row2 - 1 do
+          for c = rect.col1 to rect.col2 - 1 do
+            m.(r).(c) <- widget
+          done
         done
-      done
+      end
+    in
+    if widget#can_focus then begin
+      set widget#allocation (`can_focus widget)
+    end else if widget#focus <> None then begin
+      set widget#allocation (get_focus widget#focus dir)
     end;
     List.iter loop widget#children
   in
@@ -25,31 +57,45 @@ let right coord = { coord with col = succ coord.col }
 let up coord = { coord with row = pred coord.row }
 let down coord = { coord with row = succ coord.row }
 
-let focus_to dir f root focused coord =
-  let rect = root#allocation in
-  let m = make_widget_matrix root in
-  let rec loop coord =
-    if coord.row < rect.row1 || coord.row >= rect.row2 || coord.col < rect.col1 || coord.col >= rect.col2 then
-      None
-    else
-      match m.(coord.row).(coord.col) with
-      | None ->
-          loop (dir coord)
-      | Some widget when widget = focused ->
-          loop (dir coord)
-      | Some widget ->
-          let rect = widget#allocation in
-          Some (widget, f rect coord)
+let focus_to (dir,incr_dir) f root focused coord =
+  let get_coord widget = 
+    let rect = widget#allocation in
+    { col = (rect.col1 + rect.col2) / 2; 
+      row = (rect.row1 + rect.row2) / 2 }
   in
-  loop coord
+  match get_focus focused#focus dir with
+  | `set_focus(widget) -> 
+    (* If the currently focused widget has a focus specification for
+       the given direction jump directly to that widget *)
+    Some(widget, get_coord widget)
+  | `none ->
+    (* Otherwise project a line in the appropriate direction until we hit a widget. *)
+    let rect = root#allocation in
+    let m = make_widget_matrix root dir in
+    let rec loop coord =
+      if coord.row < rect.row1 || coord.row >= rect.row2 || coord.col < rect.col1 || coord.col >= rect.col2 then
+        None
+      else
+        match m.(coord.row).(coord.col) with
+        | `none ->
+            loop (incr_dir coord)
+        | `can_focus widget when widget = focused ->
+            loop (incr_dir coord)
+        | `can_focus widget ->
+            let rect = widget#allocation in
+            Some (widget, f rect coord)
+        | `set_focus widget -> (* note; this allows widget=focused, if specified *)
+            Some (widget, get_coord widget)
+    in
+    loop coord
 
 let avg_col rect coord = { coord with col = (rect.col1 + rect.col2) / 2 }
 let avg_row rect coord = { coord with row = (rect.row1 + rect.row2) / 2 }
 
-let focus_left (* root focused coord *) = focus_to left avg_col
-let focus_right (* root focused coord *) = focus_to right avg_col
-let focus_up (* root focused coord *) = focus_to up avg_row
-let focus_down (* root focused coord *) = focus_to down avg_row
+let focus_left (* root focused coord *) = focus_to (`left,left) avg_col
+let focus_right (* root focused coord *) = focus_to (`right,right) avg_col
+let focus_up (* root focused coord *) = focus_to (`up,up) avg_row
+let focus_down (* root focused coord *) = focus_to (`down,down) avg_row
 
 class toplevel focused widget = object(self)
   inherit t "toplevel" as super

--- a/src/widget_impl/lTerm_widget_base_impl.ml
+++ b/src/widget_impl/lTerm_widget_base_impl.ml
@@ -15,6 +15,8 @@ class t initial_resource_class : object
   method parent : t option
   method set_parent : t option -> unit
   method can_focus : bool
+  method focus : (t option * t option * t option * t option) option
+  method set_focus : ?left:t -> ?right:t -> ?up:t -> ?down:t -> unit -> unit
   method queue_draw : unit
   method set_queue_draw : (unit -> unit) -> unit
   method draw : LTerm_draw.context -> t -> unit
@@ -34,6 +36,13 @@ end = object(self)
   method children : t list = []
 
   method can_focus = false
+
+  val mutable focus = None
+  method focus = focus
+  method set_focus ?left ?right ?up ?down () = 
+    focus <- 
+      (if left=None && right=None && up=None && down=None then None
+      else Some(left,right,up,down))
 
   val mutable parent : t option = None
   method parent = parent

--- a/src/widget_impl/lTerm_widget_base_impl.ml
+++ b/src/widget_impl/lTerm_widget_base_impl.ml
@@ -31,7 +31,7 @@ class t initial_resource_class : object
   method resource_class : string
   method set_resource_class : string -> unit
   method update_resources : unit
-end = object(self)
+end = object(self) 
 
   method children : t list = []
 
@@ -39,7 +39,15 @@ end = object(self)
 
   val mutable focus = LTerm_geom.({ left=None; right=None; up=None; down=None })
   method focus = focus
-  method set_focus f = focus <- f
+  method set_focus f = 
+    let check = 
+      function None -> () 
+             | Some(x) -> 
+                if not ((x : t)#can_focus) then 
+                  failwith "set_focus: target widget must have can_focus=true"
+    in
+    check f.left; check f.right; check f.up; check f.down;
+    focus <- f
 
   val mutable parent : t option = None
   method parent = parent

--- a/src/widget_impl/lTerm_widget_base_impl.ml
+++ b/src/widget_impl/lTerm_widget_base_impl.ml
@@ -15,8 +15,8 @@ class t initial_resource_class : object
   method parent : t option
   method set_parent : t option -> unit
   method can_focus : bool
-  method focus : (t option * t option * t option * t option) option
-  method set_focus : ?left:t -> ?right:t -> ?up:t -> ?down:t -> unit -> unit
+  method focus : t option LTerm_geom.directions
+  method set_focus : t option LTerm_geom.directions -> unit
   method queue_draw : unit
   method set_queue_draw : (unit -> unit) -> unit
   method draw : LTerm_draw.context -> t -> unit
@@ -37,12 +37,9 @@ end = object(self)
 
   method can_focus = false
 
-  val mutable focus = None
+  val mutable focus = LTerm_geom.({ left=None; right=None; up=None; down=None })
   method focus = focus
-  method set_focus ?left ?right ?up ?down () = 
-    focus <- 
-      (if left=None && right=None && up=None && down=None then None
-      else Some(left,right,up,down))
+  method set_focus f = focus <- f
 
   val mutable parent : t option = None
   method parent = parent


### PR DESCRIPTION
`focus` and `set_focus` are added to `LTerm_widget.t` to specify
how focus moves among widgets.

From a currently focused widget we can specify the target widget
in each direction.

Otherwise a search is performed.  Widgets with `can_focus=false`
can take part in the search and specify a target widget.