### PR TITLE
Support mouse clicks on widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _build/
 *.swp
 *.native
 /lambda-term-api.docdir
+*~

--- a/examples/buttons.ml
+++ b/examples/buttons.ml
@@ -15,16 +15,23 @@ let main () =
 
   let vbox = new vbox in
   let button = new button "exit" in
+  let label = new label "_" in
   button#on_click (wakeup wakener);
   vbox#add button;
+  vbox#add label;
 
   for i = 0 to 2 do
     let hbox = new hbox in
-    hbox#add (new button ("button" ^ string_of_int (i * 3 + 1)));
+    let button i = 
+      let button = new button ("button" ^ string_of_int i) in
+      button#on_click (fun () -> label#set_text (string_of_int i));
+      button
+    in
+    hbox#add (button (i * 3 + 1));
     hbox#add ~expand:false (new vline);
-    hbox#add (new button ("button" ^ string_of_int (i * 3 + 2)));
+    hbox#add (button (i * 3 + 2));
     hbox#add ~expand:false (new vline);
-    hbox#add (new button ("button" ^ string_of_int (i * 3 + 3)));
+    hbox#add (button (i * 3 + 3));
     vbox#add ~expand:false (new hline);
     vbox#add hbox
   done;
@@ -32,8 +39,11 @@ let main () =
   let frame = new frame in
   frame#set vbox;
 
-  Lazy.force LTerm.stdout
-  >>= fun term ->
-  run term frame waiter
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term frame waiter)
+    (fun () -> LTerm.disable_mouse term)
+
 
 let () = Lwt_main.run (main ())

--- a/examples/radiobuttons.ml
+++ b/examples/radiobuttons.ml
@@ -67,8 +67,10 @@ let main () =
   let frame = new frame in
   frame#set vbox;
 
-  Lazy.force LTerm.stdout
-  >>= fun term ->
-  run term frame waiter
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term frame waiter)
+    (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/src/lTerm_geom.ml
+++ b/src/lTerm_geom.ml
@@ -48,6 +48,12 @@ let string_of_rect rect =
     "{ row1 = %d; col1 = %d; row2 = %d; col2 = %d }"
     rect.row1 rect.col1 rect.row2 rect.col2
 
+let in_rect rect coord = 
+  coord.col >= rect.col1 &&
+  coord.col < rect.col2 &&
+  coord.row >= rect.row1 &&
+  coord.row < rect.row2 
+
 type horz_alignment =
   | H_align_left
   | H_align_center

--- a/src/lTerm_geom.mli
+++ b/src/lTerm_geom.mli
@@ -52,6 +52,9 @@ val size_of_rect : rect -> size
 val string_of_rect : rect -> string
   (** Returns the string representation of the given rectangle. *)
 
+val in_rect : rect -> coord -> bool
+  (** Test if coord is within rect *)
+
 (** Horizontal alignment. *)
 type horz_alignment =
   | H_align_left

--- a/src/lTerm_mouse.ml
+++ b/src/lTerm_mouse.ml
@@ -34,6 +34,7 @@ let meta m = m.meta
 let button m = m.button
 let row m = m.row
 let col m = m.col
+let coord m = { LTerm_geom.row = row m; col = col m }
 
 let string_of_button = function
   | Button1 -> "Button1"

--- a/src/lTerm_mouse.mli
+++ b/src/lTerm_mouse.mli
@@ -47,6 +47,7 @@ val meta : t -> bool
 val button : t -> button
 val row : t -> int
 val col : t -> int
+val coord : t -> LTerm_geom.coord
 
 val to_string : t -> string
   (** Returns the string representation of the given mouse event. *)

--- a/src/widget_impl/lTerm_toplevel_impl.ml
+++ b/src/widget_impl/lTerm_toplevel_impl.ml
@@ -121,14 +121,16 @@ class toplevel focused widget = object(self)
     coord <- { row = (rect.row1 + rect.row2) / 2;
                col = (rect.col1 + rect.col2) / 2 }
 
-  method private move_focus direction =
-    match direction (self :> t) !focused coord with
+  method move_focus_to = function
     | Some (widget, c) ->
       coord <- c;
       focused := widget;
       self#queue_draw
     | None ->
       ()
+
+  method private move_focus direction =
+    self#move_focus_to @@ direction (self :> t) !focused coord 
 
   method private process_arrows = function
     | LTerm_event.Key { control = false; meta = false; shift = false; code = Left } ->
@@ -143,6 +145,7 @@ class toplevel focused widget = object(self)
     | LTerm_event.Key { control = false; meta = false; shift = false; code = Down } ->
         self#move_focus focus_down;
         true
+
     | other_event ->
         false
 


### PR DESCRIPTION
Update button widgets to support mouse.  Enable mouse support
on the buttons and radiobuttons widget examples.