### PR TITLE
Scrollbar widget

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -157,7 +157,12 @@ Executable scroll
   MainIs: scroll.ml
   BuildDepends: lambda-term
 
+Flag images
+  Description: Build ascii art example (requires camlimages)
+  Default: false
+
 Executable asciiart
+  Build$: flag(images)
   Path: examples
   Install: false
   CompiledObject: best

--- a/_oasis
+++ b/_oasis
@@ -157,6 +157,13 @@ Executable scroll
   MainIs: scroll.ml
   BuildDepends: lambda-term
 
+Executable scroll_debug
+  Path: examples
+  Install: false
+  CompiledObject: best
+  MainIs: scroll_debug.ml
+  BuildDepends: lambda-term
+
 Flag images
   Description: Build ascii art example (requires camlimages)
   Default: false

--- a/_oasis
+++ b/_oasis
@@ -70,6 +70,7 @@ Library "lambda-term"
     widget_impl/LTerm_widget_base_impl,
     widget_impl/LTerm_buttons_impl,
     widget_impl/LTerm_containers_impl,
+    widget_impl/LTerm_scroll_impl,
     widget_impl/LTerm_running_impl,
     widget_impl/LTerm_toplevel_impl
   CSources:
@@ -148,6 +149,20 @@ Executable focus
   CompiledObject: best
   MainIs: focus.ml
   BuildDepends: lambda-term
+
+Executable scroll
+  Path: examples
+  Install: false
+  CompiledObject: best
+  MainIs: scroll.ml
+  BuildDepends: lambda-term
+
+Executable asciiart
+  Path: examples
+  Install: false
+  CompiledObject: best
+  MainIs: asciiart.ml
+  BuildDepends: lambda-term, camlimages.png, camlimages.jpeg
 
 Executable checkbuttons
   Path: examples

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -1,0 +1,105 @@
+(*let palette = "@#8&o:*. "*)
+let palette = " .*:o&8#@"
+let coefs = [| 0.229; 0.587; 0.114 |]
+
+let load file = 
+  let img = OImages.load file [] in
+  match OImages.tag img with
+  | OImages.Index8 img 
+  | OImages.Index16 img -> img#to_rgb24
+  | OImages.Rgb24 img -> img
+  | _ -> failwith "not supported"
+
+let avg_cols = ref 5
+let avg_rows = ref 10
+let filename = ref "test.png"
+
+let () = Arg.(parse [
+  "-cols", Set_int avg_cols, "num cols to average";
+  "-rows", Set_int avg_rows, "num rows to average";
+] (fun s -> filename := s) "asciiart [options] filename")
+
+let indices img = 
+  let rows = img#height in
+  let cols = img#width in
+  let avg = float_of_int (!avg_rows * !avg_cols) in
+  let luma r g b = 
+    ((float_of_int r *. coefs.(0)) +.
+     (float_of_int g *. coefs.(1)) +.
+     (float_of_int b *. coefs.(2)))
+  in
+  Array.init (rows / !avg_rows) (fun row ->
+    Array.init (cols / !avg_cols) (fun col ->
+      let sum = ref 0. in
+      for row=row * !avg_rows to ((row+1) * !avg_rows)-1 do
+        for col=col * !avg_cols to ((col+1) * !avg_cols)-1 do
+          let pel = img#get col row in
+          sum := !sum +. (luma pel.Images.r pel.Images.g pel.Images.b)
+        done
+      done;
+      let sum = !sum /. (256. *. avg) in
+      max 0 @@ min 8 (int_of_float (sum *. 9.))))
+
+open Lwt
+open LTerm_widget
+open LTerm_geom
+open CamomileLibrary
+
+class asciiart img = object(self)
+  inherit t "asciiart"
+
+  method can_focus = false
+
+  method full_size = { rows = Array.length img - 1; cols=Array.length img.(0) - 1 }
+
+  val mutable offset = { row = 0; col = 0 }
+  method offset = offset
+  method set_offset o = offset <- o; self#queue_draw
+
+  val style = 
+    LTerm_style.({ none with foreground=Some white; 
+                             background=Some black }) 
+
+  method draw ctx focused = 
+    let { rows; cols } = LTerm_draw.size ctx in
+    for row=0 to rows-1 do
+      for col=0 to cols-1 do
+        LTerm_draw.draw_char ~style ctx row col @@ 
+          UChar.of_char palette.[ try img.(row+offset.row).(col+offset.col) with _ -> 0 ]
+      done
+    done
+
+end
+
+let main () = 
+  let img = indices (load !filename) in
+
+  let waiter, wakener = wait () in
+  let exit = new button "exit" in
+  exit#on_click (wakeup wakener);
+
+  let vbox = new vbox in
+  let hbox = new hbox in
+  let art = new asciiart img in
+  let vscroll = new vscrollbar (art :> scrollable) in
+  let hscroll = new hscrollbar (art :> scrollable) in
+
+  art#set_focus { art#focus with right = Some(vscroll); down = Some(hscroll :> t) };
+  vscroll#set_focus { vscroll#focus with down = Some(hscroll :> t) };
+  hscroll#set_focus { hscroll#focus with up = Some(vscroll); down = Some(exit :> t) } ;
+
+
+  hbox#add art;
+  hbox#add ~expand:false vscroll;
+  vbox#add hbox;
+  vbox#add ~expand:false hscroll;
+  vbox#add ~expand:false exit;
+
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term vbox waiter)
+    (fun () -> LTerm.disable_mouse term)
+
+let () = Lwt_main.run (main ())
+

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -110,7 +110,7 @@ class asciiart img = object(self)
       done
     done
 
-  initializer self#on_event (fun ev ->
+  method private event_handler ev =
     let open LTerm_mouse in
     match ev with
     | LTerm_event.Mouse m when m.button=Button1 ->
@@ -139,12 +139,20 @@ class asciiart img = object(self)
       avg_cols := !avg_cols + 1; 
       hscroll#set_document_size self#document_size.cols;
       self#queue_draw; true
+    | _ -> false
+
+  method private scroll_handler = function
     (* page up/down *)
     | LTerm_event.Key{LTerm_key.code=LTerm_key.Next_page} ->
       vscroll#set_offset @@ vscroll#page_next; self#queue_draw; true
     | LTerm_event.Key{LTerm_key.code=LTerm_key.Prev_page} ->
       vscroll#set_offset @@ vscroll#page_prev; self#queue_draw; true
-    | _ -> false)
+    | _ -> false
+
+  initializer 
+    vscroll#add_scroll_event_handler self#scroll_handler;
+    hscroll#add_scroll_event_handler self#scroll_handler;
+    self#on_event (fun ev -> self#event_handler ev || self#scroll_handler ev)
 
 end
 

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -96,12 +96,11 @@ end
 let with_scrollbar ?down widget = 
   let vbox = new vbox in
   let hbox = new hbox in
-  let vscroll = (* make scroll bars roughly the same size *)
-    new vscrollbar ~size_request:{rows=0;cols=3} ~default_scroll_bar_size:5 () 
-  in
-  let hscroll = 
-    new hscrollbar ~size_request:{rows=2;cols=0} ~default_scroll_bar_size:10 () 
-  in
+  (* make scroll bars roughly the same size *)
+  let vscroll = new vscrollbar ~width:3 () in
+  vscroll#set_scroll_bar_mode (`fixed 5);
+  let hscroll = new hscrollbar ~height:2 () in
+  hscroll#set_scroll_bar_mode (`fixed 10);
   let spacing = new spacing ~rows:2 ~cols:3 () in
   let widget = widget vscroll hscroll in
   hbox#add widget;

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -72,6 +72,8 @@ class asciiart img = object(self)
     cols = img#width / !avg_cols;
   }
 
+  method page_size = size_of_rect self#allocation
+
   val mutable voffset = 0
   val mutable hoffset = 0
   method set_voffset o = voffset <- o
@@ -107,8 +109,8 @@ let with_scrollbar ?down widget =
   let vbox = new vbox in
   let hbox = new hbox in
   (* make scroll bars roughly the same size *)
-  let vscroll = new vscrollbar_for_widget ~width:3 widget in
-  let hscroll = new hscrollbar_for_widget ~height:2 widget in
+  let vscroll = new vscrollbar_for_document ~width:3 widget in
+  let hscroll = new hscrollbar_for_document ~height:2 widget in
   let spacing = new spacing ~rows:2 ~cols:3 () in
   hbox#add widget;
   hbox#add ~expand:false (new vline);

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -115,6 +115,7 @@ class asciiart img = object(self)
       self#hscroll#set_offset 
         (self#hscroll#offset + m.LTerm_mouse.col - alloc.col1 - size.cols/2);
       true
+    (* adjust scale, which changes the document size *)
     | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c} when c = UChar.of_char 'w' ->
       avg_rows := max 1 (!avg_rows - 1);
       doc#set_document_size self#document_size;
@@ -131,6 +132,7 @@ class asciiart img = object(self)
       avg_cols := !avg_cols + 1; 
       doc#set_document_size self#document_size;
       self#queue_draw; true
+    (* page up/down *)
     | LTerm_event.Key{LTerm_key.code=LTerm_key.Next_page} ->
       doc#page.down (); self#queue_draw; true
     | LTerm_event.Key{LTerm_key.code=LTerm_key.Prev_page} ->

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -62,13 +62,19 @@ open CamomileLibrary
 
 (* scrollable asciiart widget *)
 class asciiart img vscroll hscroll = object(self)
-  inherit t "asciiart"
+  inherit t "asciiart" as super
 
-  initializer
+  (*initializer
     vscroll#set_range (Array.length img);
-    hscroll#set_range (Array.length img.(0))
+    hscroll#set_range (Array.length img.(0))*)
 
   method can_focus = false
+
+  method set_allocation rect =
+    let size = size_of_rect rect in
+    vscroll#set_range (max 1 (Array.length img - size.rows));
+    hscroll#set_range (max 1 (Array.length img.(0) - size.cols));
+    super#set_allocation rect
 
   val style = 
     LTerm_style.({ none with foreground=Some white; 

--- a/examples/asciiart.ml
+++ b/examples/asciiart.ml
@@ -74,9 +74,7 @@ class asciiart img = object(self)
   }
 
   initializer
-    doc#set_document_size self#document_size;
-    doc#vscroll#on_offset_change (fun _ -> self#queue_draw);
-    doc#hscroll#on_offset_change (fun _ -> self#queue_draw)
+    doc#set_document_size self#document_size
 
   method set_allocation r = 
     super#set_allocation r;
@@ -133,6 +131,10 @@ class asciiart img = object(self)
       avg_cols := !avg_cols + 1; 
       doc#set_document_size self#document_size;
       self#queue_draw; true
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Next_page} ->
+      doc#page.down (); self#queue_draw; true
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Prev_page} ->
+      doc#page.up (); self#queue_draw; true
     | _ -> false)
 
 end

--- a/examples/checkbuttons.ml
+++ b/examples/checkbuttons.ml
@@ -55,8 +55,10 @@ let main () =
   let frame = new frame in
   frame#set vbox;
 
-  Lazy.force LTerm.stdout
-  >>= fun term ->
-  run term frame waiter
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term frame waiter)
+    (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -16,7 +16,7 @@ let main () =
   let hbox = new LTerm_widget.hbox in
   let frame = new LTerm_widget.frame in
   let editor = new LTerm_edit.edit () in
-  let vscroll = new LTerm_widget.vscrollbar_for_document editor in
+  let vscroll = new LTerm_widget.vscrollbar editor#vscroll in
   frame#set editor;
   hbox#add frame;
   hbox#add vscroll;
@@ -31,20 +31,51 @@ let main () =
      ])
     [ LTerm_edit.Custom (fun () -> wakeup wakener ()) ];
 
+  let txt = String.concat "\n" @@ Array.to_list @@ 
+    Array.init 150 (fun i -> Printf.sprintf "%.9i" i) in
   Zed_edit.insert editor#context
-    (Zed_rope.of_string "\
+(*    (Zed_rope.of_string "\
 This is a simple edition widget.
 
 Type C-x C-c to exit.
 
-");
+");*)
+    (Zed_rope.of_string txt);
+
+  let show f = 
+    let open LTerm_geom in
+    let open Printf in
+    let engine = editor#engine in
+    let line_set = Zed_edit.lines engine in
+    let start_line = Zed_lines.line_index line_set editor#start in
+    let cursor_offset = Zed_cursor.get_position editor#cursor in
+    let cursor_line = Zed_lines.line_index line_set cursor_offset in
+    ksprintf f "page=%i doc=%i offset=%i range=%i \
+                start=%i shift=%i start_line=%i/%i offsets=%i \
+                cursor=%i/%i delta=%i"
+      editor#vscroll#page_size
+      editor#vscroll#document_size
+      editor#vscroll#offset
+      editor#vscroll#range
+      editor#start editor#shift 
+      editor#start_line start_line
+      editor#offset_count
+      cursor_offset cursor_line
+      editor#delta
+  in
+
+  let vbox = new LTerm_widget.vbox in
+  let debug = new LTerm_widget.label "_" in
+  vbox#add hbox;
+  vbox#add debug;
+  ignore (Lwt_engine.on_timer 0.1 true (fun _ -> show debug#set_text));
 
   Lazy.force LTerm.stdout
   >>= fun term ->
   LTerm.enable_mouse term
   >>= fun () ->
   Lwt.finalize
-    (fun () -> LTerm_widget.run term hbox waiter)
+    (fun () -> LTerm_widget.run term vbox waiter)
     (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -16,10 +16,10 @@ let main () =
   let hbox = new LTerm_widget.hbox in
   let frame = new LTerm_widget.frame in
   let editor = new LTerm_edit.edit () in
-  let vscroll = new LTerm_widget.vscrollbar editor#vscroll in
+  let vscroll = new LTerm_widget.vscrollbar ~width:1 editor#vscroll in
   frame#set editor;
   hbox#add frame;
-  hbox#add vscroll;
+  hbox#add ~expand:false vscroll;
 
   (* Exit when the user presses C-x C-c *)
   editor#bind

--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -13,10 +13,13 @@ open Lwt
 let main () =
   let waiter, wakener = wait () in
 
+  let hbox = new LTerm_widget.hbox in
   let frame = new LTerm_widget.frame in
   let editor = new LTerm_edit.edit () in
-
+  let vscroll = new LTerm_widget.vscrollbar_for_document editor in
   frame#set editor;
+  hbox#add frame;
+  hbox#add vscroll;
 
   (* Exit when the user presses C-x C-c *)
   editor#bind
@@ -38,6 +41,10 @@ Type C-x C-c to exit.
 
   Lazy.force LTerm.stdout
   >>= fun term ->
-  LTerm_widget.run term frame waiter
+  LTerm.enable_mouse term
+  >>= fun () ->
+  Lwt.finalize
+    (fun () -> LTerm_widget.run term hbox waiter)
+    (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -31,51 +31,20 @@ let main () =
      ])
     [ LTerm_edit.Custom (fun () -> wakeup wakener ()) ];
 
-  let txt = String.concat "\n" @@ Array.to_list @@ 
-    Array.init 150 (fun i -> Printf.sprintf "%.9i" i) in
   Zed_edit.insert editor#context
-(*    (Zed_rope.of_string "\
+    (Zed_rope.of_string "\
 This is a simple edition widget.
 
 Type C-x C-c to exit.
 
-");*)
-    (Zed_rope.of_string txt);
-
-  let show f = 
-    let open LTerm_geom in
-    let open Printf in
-    let engine = editor#engine in
-    let line_set = Zed_edit.lines engine in
-    let start_line = Zed_lines.line_index line_set editor#start in
-    let cursor_offset = Zed_cursor.get_position editor#cursor in
-    let cursor_line = Zed_lines.line_index line_set cursor_offset in
-    ksprintf f "page=%i doc=%i offset=%i range=%i \
-                start=%i shift=%i start_line=%i/%i offsets=%i \
-                cursor=%i/%i delta=%i"
-      editor#vscroll#page_size
-      editor#vscroll#document_size
-      editor#vscroll#offset
-      editor#vscroll#range
-      editor#start editor#shift 
-      editor#start_line start_line
-      editor#offset_count
-      cursor_offset cursor_line
-      editor#delta
-  in
-
-  let vbox = new LTerm_widget.vbox in
-  let debug = new LTerm_widget.label "_" in
-  vbox#add hbox;
-  vbox#add debug;
-  ignore (Lwt_engine.on_timer 0.1 true (fun _ -> show debug#set_text));
+");
 
   Lazy.force LTerm.stdout
   >>= fun term ->
   LTerm.enable_mouse term
   >>= fun () ->
   Lwt.finalize
-    (fun () -> LTerm_widget.run term vbox waiter)
+    (fun () -> LTerm_widget.run term hbox waiter)
     (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -11,7 +11,7 @@ open LTerm_widget
 open LTerm_geom
 
 (* a simple widget with scrollbar support *)
-class scrollable_nums scroll = object(self)
+class scrollable_nums (scroll : scrollable) = object(self)
   inherit t "nums" as super
 
   initializer scroll#set_range 197
@@ -33,8 +33,9 @@ let main () =
   let exit = new button "exit" in
   exit#on_click (wakeup wakener);
 
-  let scroll = new vscrollbar () in
-  let nums = new scrollable_nums scroll in
+  let adj = new scrollable in
+  let scroll = new vscrollbar adj in
+  let nums = new scrollable_nums adj in
 
   let hbox = new hbox in
   hbox#add ~expand:true nums;
@@ -42,13 +43,13 @@ let main () =
 
   (* buttons to set scroll offset *)
   let prev = new button "prev" in
-  prev#on_click (fun () -> scroll#set_offset (scroll#offset-1));
+  prev#on_click (fun () -> adj#set_offset (adj#offset-1));
   let next = new button "next" in
-  next#on_click (fun () -> scroll#set_offset (scroll#offset+1));
+  next#on_click (fun () -> adj#set_offset (adj#offset+1));
   let decr = new button "decr" in
-  decr#on_click (fun () -> scroll#decr);
+  decr#on_click (fun () -> adj#set_offset adj#decr);
   let incr = new button "incr" in
-  incr#on_click (fun () -> scroll#incr);
+  incr#on_click (fun () -> adj#set_offset adj#incr);
 
   let vbox = new vbox in
   vbox#add hbox;

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -1,0 +1,68 @@
+(*
+ * scroll.ml
+ * ----------
+ * Copyright : (c) 2016, Andy Ray <andy.ray@ujamjar.com>
+ * Licence   : BSD3
+ *
+ * This file is a part of Lambda-Term.
+ *)
+open Lwt
+open LTerm_widget
+open LTerm_geom
+
+class scrollable_nums = object(self)
+  inherit t "nums"
+
+  method can_focus = false
+
+  method full_size = { rows = 199; cols=40 }
+
+  val mutable offset = { row = 0; col = 0 }
+  method offset = offset
+  method set_offset o = offset <- o; self#queue_draw
+
+  method draw ctx focused = 
+    let { rows; cols } = LTerm_draw.size ctx in
+
+    for row=0 to rows-1 do
+      LTerm_draw.draw_string ctx row 0 (string_of_int (row + offset.row))
+    done
+
+end
+
+let main () = 
+  let waiter, wakener = wait () in
+
+  let exit = new button "exit" in
+  exit#on_click (wakeup wakener);
+
+  let nums = new scrollable_nums in
+  let scroll = new vscrollbar (nums :> scrollable) in
+  let hbox = new hbox in
+  hbox#add ~expand:true nums;
+  hbox#add ~expand:false scroll;
+
+  let decr = new button "decr" in
+  let set_offset f = 
+    let o = nums#offset in 
+    nums#set_offset { o with row = f o.row } 
+  in
+  decr#on_click (fun () -> set_offset ((+)(-1)));
+  let incr = new button "incr" in
+  incr#on_click (fun () -> set_offset ((+)1));
+
+  let vbox = new vbox in
+  vbox#add hbox;
+  vbox#add ~expand:false (new hline);
+  vbox#add ~expand:false decr;
+  vbox#add ~expand:false incr;
+  vbox#add ~expand:false exit;
+
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term vbox waiter)
+    (fun () -> LTerm.disable_mouse term)
+
+let () = Lwt_main.run (main ())
+

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -10,6 +10,7 @@ open Lwt
 open LTerm_widget
 open LTerm_geom
 
+(* a simple widget with scrollbar support *)
 class scrollable_nums = object(self)
   inherit t "nums"
 
@@ -37,16 +38,18 @@ let main () =
   exit#on_click (wakeup wakener);
 
   let nums = new scrollable_nums in
-  let scroll = new vscrollbar (nums :> scrollable) in
+  let scroll = new vscrollbar nums in
+
   let hbox = new hbox in
   hbox#add ~expand:true nums;
   hbox#add ~expand:false scroll;
 
-  let decr = new button "decr" in
+  (* buttons to set scroll offset *)
   let set_offset f = 
     let o = nums#offset in 
     nums#set_offset { o with row = f o.row } 
   in
+  let decr = new button "decr" in
   decr#on_click (fun () -> set_offset ((+)(-1)));
   let incr = new button "incr" in
   incr#on_click (fun () -> set_offset ((+)1));

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -11,22 +11,20 @@ open LTerm_widget
 open LTerm_geom
 
 (* a simple widget with scrollbar support *)
-class scrollable_nums = object(self)
-  inherit t "nums"
+class scrollable_nums scroll = object(self)
+  inherit t "nums" as super
+
+  initializer scroll#set_range 197
 
   method can_focus = false
 
-  method full_size = { rows = 199; cols=40 }
-
-  val mutable offset = { row = 0; col = 0 }
-  method offset = offset
-  method set_offset o = offset <- o; self#queue_draw
+  method full_size = { rows = 0; cols=40 }
 
   method draw ctx focused = 
     let { rows; cols } = LTerm_draw.size ctx in
 
     for row=0 to rows-1 do
-      LTerm_draw.draw_string ctx row 0 (string_of_int (row + offset.row))
+      LTerm_draw.draw_string ctx row 0 (string_of_int (row + scroll#offset))
     done
 
 end
@@ -37,26 +35,28 @@ let main () =
   let exit = new button "exit" in
   exit#on_click (wakeup wakener);
 
-  let nums = new scrollable_nums in
-  let scroll = new vscrollbar nums in
+  let scroll = new vscrollbar () in
+  let nums = new scrollable_nums scroll in
 
   let hbox = new hbox in
   hbox#add ~expand:true nums;
   hbox#add ~expand:false scroll;
 
   (* buttons to set scroll offset *)
-  let set_offset f = 
-    let o = nums#offset in 
-    nums#set_offset { o with row = f o.row } 
-  in
+  let prev = new button "prev" in
+  prev#on_click (fun () -> scroll#set_offset (scroll#offset-1));
+  let next = new button "next" in
+  next#on_click (fun () -> scroll#set_offset (scroll#offset+1));
   let decr = new button "decr" in
-  decr#on_click (fun () -> set_offset ((+)(-1)));
+  decr#on_click (fun () -> scroll#decr);
   let incr = new button "incr" in
-  incr#on_click (fun () -> set_offset ((+)1));
+  incr#on_click (fun () -> scroll#incr);
 
   let vbox = new vbox in
   vbox#add hbox;
   vbox#add ~expand:false (new hline);
+  vbox#add ~expand:false prev;
+  vbox#add ~expand:false next;
   vbox#add ~expand:false decr;
   vbox#add ~expand:false incr;
   vbox#add ~expand:false exit;

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -51,6 +51,8 @@ let main () =
   let incr = new button "incr" in
   incr#on_click (fun () -> adj#set_offset adj#incr);
 
+  adj#on_offset_change (fun _ -> scroll#queue_draw);
+
   let vbox = new vbox in
   vbox#add hbox;
   vbox#add ~expand:false (new hline);

--- a/examples/scroll.ml
+++ b/examples/scroll.ml
@@ -18,8 +18,6 @@ class scrollable_nums scroll = object(self)
 
   method can_focus = false
 
-  method full_size = { rows = 0; cols=40 }
-
   method draw ctx focused = 
     let { rows; cols } = LTerm_draw.size ctx in
 

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -1,0 +1,70 @@
+(*
+ * scroll_debug.ml
+ * ----------
+ * Copyright : (c) 2016, Andy Ray <andy.ray@ujamjar.com>
+ * Licence   : BSD3
+ *
+ * This file is a part of Lambda-Term.
+ *)
+
+open Lwt
+open LTerm_widget
+open LTerm_geom
+
+class scroll_label scroll = object(self)
+  inherit label "scroll"
+  method can_focus = false
+  method size_request = { rows=1; cols=0 }
+  method draw ctx focused = 
+    let alloc = size_of_rect scroll#allocation in
+    LTerm_draw.draw_string ctx 0 0 
+      (Printf.sprintf "%i/%i | %ix%i | %i/%i/%i" 
+        scroll#offset scroll#range
+        alloc.rows alloc.cols
+        scroll#debug_offset scroll#debug_size scroll#debug_steps
+      )
+
+end
+
+let main () = 
+  let waiter, wakener = wait () in
+  let exit = new button "exit" in
+  exit#on_click (wakeup wakener);
+
+  let vbox = new vbox in
+
+  let add_scroll (vbox : vbox) ~range ~size = 
+    let hscroll = new hscrollbar ~default_scroll_bar_size:size () in
+    let label = new scroll_label hscroll in
+    hscroll#set_range range;
+    vbox#add ~expand:false (label :> t);
+    vbox#add ~expand:false (new hline);
+    vbox#add ~expand:false (hscroll :> t);
+    vbox#add ~expand:false (new hline);
+    hscroll
+  in
+
+  let scrolls = List.map (fun (range,size) -> add_scroll vbox ~range ~size)
+    [ 10,10;  100, 10;  1000, 10;
+      10,100; 100, 100; 1000, 100; ]
+  in
+
+  vbox#add ~expand:true (new spacing ());
+  let mouse_mode = new radiogroup in
+  mouse_mode#on_state_change (function
+    | None -> () 
+    | Some(m) -> List.iter (fun h -> h#set_mouse_mode m) scrolls);
+  vbox#add ~expand:false (new radiobutton mouse_mode "ratio" `ratio);
+  vbox#add ~expand:false (new radiobutton mouse_mode "middle" `middle);
+  vbox#add ~expand:false (new radiobutton mouse_mode "left" `left);
+  vbox#add ~expand:false (new radiobutton mouse_mode "right" `right);
+  vbox#add ~expand:false exit;
+
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize 
+    (fun () -> run term vbox waiter)
+    (fun () -> LTerm.disable_mouse term)
+
+let () = Lwt_main.run (main ())
+

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -51,7 +51,7 @@ let main () =
 
   let scrolls = List.map 
     (fun range -> add_scroll vbox ~range ~size:1)
-    [ 10; 30; 60; 100; 200; 1000 ]
+    [ 0; 10; 30; 60; 100; 200; 1000 ]
   in
 
   let mouse_mode = 
@@ -78,15 +78,14 @@ let main () =
       scroll#set_range range; (* mini-scroll bars to test the scroll bars...?! *)
       scroll#set_mouse_mode `middle;
       scroll#set_scroll_bar_mode (`fixed 1);
-      vbox#add ~expand:false (new spacing ~cols:10 ());
+      vbox#add ~expand:false (new spacing ~cols:range ());
       vbox#add ~expand:false scroll;
       button, scroll, vbox
     in
 
-
     vbox#add ~expand:false (new label "scroll mode");
-    let f,fr,fb = ranged_widget scroll_mode "fixed " `fixed 20 in
-    let d,dr,db = ranged_widget scroll_mode "dynamic " `dynamic 20 in
+    let f,fr,fb = ranged_widget scroll_mode "fixed " `fixed 10 in
+    let d,dr,db = ranged_widget scroll_mode "dynamic " `dynamic 10 in
     let sbox = 
       let in_frame w = let f = new frame in f#set w; f in
       let v1 = new vbox in
@@ -104,7 +103,7 @@ let main () =
 
     let set_mode f o = List.iter (fun h -> h#set_scroll_bar_mode (f o)) scrolls in
     let fixed o = `fixed ((o*5)+1) in
-    let dynamic o = `dynamic o in
+    let dynamic o = `dynamic (o*50) in
 
     scroll_mode#on_state_change (function
       | None -> ()

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -71,28 +71,22 @@ let main () =
     let scroll_mode = new radiogroup in
 
     let ranged_widget group name value range = 
-      let vbox = new vbox in
       let button = new radiobutton group name value in
-      let scroll = new hscrollbar ~height:1 () in
-      scroll#set_range range; (* mini-scroll bars to test the scroll bars...?! *)
-      scroll#set_mouse_mode `middle;
-      scroll#set_scroll_bar_mode (`fixed 1);
-      vbox#add ~expand:false (new spacing ~cols:range ());
-      vbox#add ~expand:false scroll;
-      button, scroll, vbox
+      let scroll = new hslider range in
+      button, scroll
     in
 
     vbox#add ~expand:false (new label "scroll mode");
-    let f,fr,fb = ranged_widget scroll_mode "fixed " `fixed 10 in
-    let d,dr,db = ranged_widget scroll_mode "dynamic " `dynamic 10 in
+    let f,fr = ranged_widget scroll_mode "fixed " `fixed 10 in
+    let d,dr = ranged_widget scroll_mode "dynamic " `dynamic 10 in
     let sbox = 
       let in_frame w = let f = new frame in f#set w; f in
       let v1 = new vbox in
       v1#add ~expand:true f;
       v1#add ~expand:true d;
       let v2 = new vbox in
-      v2#add ~expand:false (in_frame fb);
-      v2#add ~expand:false (in_frame db);
+      v2#add ~expand:false (in_frame fr);
+      v2#add ~expand:false (in_frame dr);
       let h = new hbox in
       h#add ~expand:false v1;
       h#add ~expand:false v2;

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -18,12 +18,9 @@ class scroll_label scroll = object(self)
   val style = LTerm_style.{none with foreground = Some red;
                                      background = Some green };
   method draw ctx focused = 
-    let alloc = size_of_rect scroll#allocation in
     LTerm_draw.fill_style ctx style;
     LTerm_draw.draw_string_aligned ctx 0 H_align_center ~style
-      (Printf.sprintf "%i/%i | %ix%i" 
-        scroll#offset scroll#range
-        alloc.rows alloc.cols)
+      (Printf.sprintf "%i/%i" scroll#offset scroll#range)
 
 end
 
@@ -35,16 +32,17 @@ let main () =
   let vbox = new vbox in
 
   let add_scroll (vbox : vbox) ~range ~size = 
-    let hscroll = new hscrollbar () in
-    let label = new scroll_label hscroll in
-    hscroll#set_range range;
-    hscroll#set_mouse_mode `middle;
-    hscroll#set_scroll_bar_mode (`fixed size);
+    let adj = new scrollable in
+    let hscroll = new hscrollbar adj in
+    let label = new scroll_label adj in
+    adj#set_range range;
+    adj#set_mouse_mode `middle;
+    adj#set_scroll_bar_mode (`fixed size);
     vbox#add ~expand:false (label :> t);
     vbox#add ~expand:false (new hline);
     vbox#add ~expand:false (hscroll :> t);
     vbox#add ~expand:false (new hline);
-    hscroll
+    adj
   in
 
   let scrolls = List.map 

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -21,11 +21,9 @@ class scroll_label scroll = object(self)
     let alloc = size_of_rect scroll#allocation in
     LTerm_draw.fill_style ctx style;
     LTerm_draw.draw_string_aligned ctx 0 H_align_center ~style
-      (Printf.sprintf "%i/%i | %ix%i | %i/%i/%i" 
+      (Printf.sprintf "%i/%i | %ix%i" 
         scroll#offset scroll#range
-        alloc.rows alloc.cols
-        scroll#debug_offset scroll#debug_size scroll#debug_steps
-      )
+        alloc.rows alloc.cols)
 
 end
 
@@ -63,6 +61,7 @@ let main () =
     vbox#add ~expand:false (new label "mouse mode");
     vbox#add ~expand:false (new radiobutton mouse_mode "middle" `middle);
     vbox#add ~expand:false (new radiobutton mouse_mode "ratio" `ratio);
+    vbox#add ~expand:false (new radiobutton mouse_mode "auto" `auto);
     vbox#add ~expand:true (new spacing ());
     vbox
   in

--- a/examples/scroll_debug.ml
+++ b/examples/scroll_debug.ml
@@ -15,9 +15,12 @@ class scroll_label scroll = object(self)
   inherit label "scroll"
   method can_focus = false
   method size_request = { rows=1; cols=0 }
+  val style = LTerm_style.{none with foreground = Some red;
+                                     background = Some green };
   method draw ctx focused = 
     let alloc = size_of_rect scroll#allocation in
-    LTerm_draw.draw_string ctx 0 0 
+    LTerm_draw.fill_style ctx style;
+    LTerm_draw.draw_string_aligned ctx 0 H_align_center ~style
       (Printf.sprintf "%i/%i | %ix%i | %i/%i/%i" 
         scroll#offset scroll#range
         alloc.rows alloc.cols
@@ -34,9 +37,11 @@ let main () =
   let vbox = new vbox in
 
   let add_scroll (vbox : vbox) ~range ~size = 
-    let hscroll = new hscrollbar ~default_scroll_bar_size:size () in
+    let hscroll = new hscrollbar () in
     let label = new scroll_label hscroll in
     hscroll#set_range range;
+    hscroll#set_mouse_mode `middle;
+    hscroll#set_scroll_bar_mode (`fixed size);
     vbox#add ~expand:false (label :> t);
     vbox#add ~expand:false (new hline);
     vbox#add ~expand:false (hscroll :> t);
@@ -44,20 +49,85 @@ let main () =
     hscroll
   in
 
-  let scrolls = List.map (fun (range,size) -> add_scroll vbox ~range ~size)
-    [ 10,10;  100, 10;  1000, 10;
-      10,100; 100, 100; 1000, 100; ]
+  let scrolls = List.map 
+    (fun range -> add_scroll vbox ~range ~size:1)
+    [ 10; 30; 60; 100; 200; 1000 ]
   in
 
+  let mouse_mode = 
+    let vbox = new vbox in
+    let mouse_mode = new radiogroup in
+    mouse_mode#on_state_change (function
+      | None -> () 
+      | Some(m) -> List.iter (fun h -> h#set_mouse_mode m) scrolls);
+    vbox#add ~expand:false (new label "mouse mode");
+    vbox#add ~expand:false (new radiobutton mouse_mode "middle" `middle);
+    vbox#add ~expand:false (new radiobutton mouse_mode "ratio" `ratio);
+    vbox#add ~expand:true (new spacing ());
+    vbox
+  in
+
+  let scroll_mode = 
+    let vbox = new vbox in
+    let scroll_mode = new radiogroup in
+
+    let ranged_widget group name value range = 
+      let vbox = new vbox in
+      let button = new radiobutton group name value in
+      let scroll = new hscrollbar ~height:1 () in
+      scroll#set_range range; (* mini-scroll bars to test the scroll bars...?! *)
+      scroll#set_mouse_mode `middle;
+      scroll#set_scroll_bar_mode (`fixed 1);
+      vbox#add ~expand:false (new spacing ~cols:10 ());
+      vbox#add ~expand:false scroll;
+      button, scroll, vbox
+    in
+
+
+    vbox#add ~expand:false (new label "scroll mode");
+    let f,fr,fb = ranged_widget scroll_mode "fixed " `fixed 20 in
+    let d,dr,db = ranged_widget scroll_mode "dynamic " `dynamic 20 in
+    let sbox = 
+      let in_frame w = let f = new frame in f#set w; f in
+      let v1 = new vbox in
+      v1#add ~expand:true f;
+      v1#add ~expand:true d;
+      let v2 = new vbox in
+      v2#add ~expand:false (in_frame fb);
+      v2#add ~expand:false (in_frame db);
+      let h = new hbox in
+      h#add ~expand:false v1;
+      h#add ~expand:false v2;
+      h
+    in
+    vbox#add ~expand:false sbox;
+
+    let set_mode f o = List.iter (fun h -> h#set_scroll_bar_mode (f o)) scrolls in
+    let fixed o = `fixed ((o*5)+1) in
+    let dynamic o = `dynamic o in
+
+    scroll_mode#on_state_change (function
+      | None -> ()
+      | Some(`fixed) -> set_mode fixed fr#offset
+      | Some(`dynamic) -> set_mode dynamic dr#offset
+    );
+
+    fr#on_offset_change (fun o -> if f#state then set_mode fixed o);
+    dr#on_offset_change (fun o -> if d#state then set_mode dynamic o);
+
+    vbox
+  in
+
+  let hbox = new hbox in
+  hbox#add (new spacing ());
+  hbox#add ~expand:false mouse_mode;
+  hbox#add (new spacing ());
+  hbox#add ~expand:false scroll_mode;
+  hbox#add (new spacing ());
+
   vbox#add ~expand:true (new spacing ());
-  let mouse_mode = new radiogroup in
-  mouse_mode#on_state_change (function
-    | None -> () 
-    | Some(m) -> List.iter (fun h -> h#set_mouse_mode m) scrolls);
-  vbox#add ~expand:false (new radiobutton mouse_mode "ratio" `ratio);
-  vbox#add ~expand:false (new radiobutton mouse_mode "middle" `middle);
-  vbox#add ~expand:false (new radiobutton mouse_mode "left" `left);
-  vbox#add ~expand:false (new radiobutton mouse_mode "right" `right);
+  vbox#add ~expand:false hbox;
+  vbox#add ~expand:true (new spacing ());
   vbox#add ~expand:false exit;
 
   Lazy.force LTerm.stdout >>= fun term ->

--- a/lambda-termrc
+++ b/lambda-termrc
@@ -6,6 +6,12 @@ radiobutton.focused.foreground: lyellow
 radiobutton.focused.background: blue
 scrollbar.focused.foreground: lyellow
 scrollbar.focused.background: blue
+scrollbar.barstyle: outline
+scrollbar.track: false
+slider.focused.foreground: lyellow
+slider.focused.background: blue
+slider.barstyle: filled
+slider.track: true
 !
 ! For monochrome experience comment out the resources above and uncomment two
 ! following lines:
@@ -14,3 +20,4 @@ scrollbar.focused.background: blue
 !checkbutton.focused.reverse: true
 !radiobutton.focused.reverse: true
 !scrollbar.focused.reverse: true
+!slider.focused.reverse: true

--- a/lambda-termrc
+++ b/lambda-termrc
@@ -4,6 +4,8 @@ checkbutton.focused.foreground: lyellow
 checkbutton.focused.background: blue
 radiobutton.focused.foreground: lyellow
 radiobutton.focused.background: blue
+scrollbar.focused.foreground: lyellow
+scrollbar.focused.background: blue
 !
 ! For monochrome experience comment out the resources above and uncomment two
 ! following lines:
@@ -11,3 +13,4 @@ radiobutton.focused.background: blue
 !button.focused.reverse: true
 !checkbutton.focused.reverse: true
 !radiobutton.focused.reverse: true
+!scrollbar.focused.reverse: true

--- a/opam
+++ b/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/lambda-term"
+bug-reports: "https://github.com/diml/lambda-term/issues"
+dev-repo: "git://github.com/diml/lambda-term.git"
+license: "BSD3"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [["ocaml" "setup.ml" "-install"]]
+build-doc: [["ocaml" "setup.ml" "-doc"]]
+remove: [["ocamlfind" "remove" "lambda-term"]]
+depends: [
+  "ocamlfind"
+  "lwt" {>= "2.4.0"}
+  "zed" {>= "1.2"}
+  "react" {>= "1.0.0"}
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.01" ]

--- a/opam
+++ b/opam
@@ -6,11 +6,10 @@ bug-reports: "https://github.com/diml/lambda-term/issues"
 dev-repo: "git://github.com/diml/lambda-term.git"
 license: "BSD3"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
-  ["ocaml" "setup.ml" "-build"]
+  ["./configure" "--prefix" prefix]
+  [make]
 ]
-install: [["ocaml" "setup.ml" "-install"]]
-build-doc: [["ocaml" "setup.ml" "-doc"]]
+install: [[make "install"]]
 remove: [["ocamlfind" "remove" "lambda-term"]]
 depends: [
   "ocamlfind"

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -167,7 +167,8 @@ let newline = UChar.of_char '\n'
 class edit ?(clipboard = clipboard) ?(macro = macro) () =
   let locale, set_locale = S.create None in
 object(self)
-  inherit LTerm_widget.t "edit"
+  inherit LTerm_widget.t "edit" as super
+  inherit LTerm_widget.default_scrollable_document as scroll
 
   method clipboard = clipboard
   method macro = macro
@@ -217,7 +218,10 @@ object(self)
     cursor <- Zed_edit.new_cursor engine;
     context <- Zed_edit.context engine cursor;
     Zed_edit.set_data engine (self :> edit);
-    event <- E.map (fun _ -> self#queue_draw) (Zed_edit.update engine [cursor]);
+    event <- E.map (fun _ -> 
+      scroll#set_document_size 
+        { cols = 0; rows = Zed_lines.count (Zed_edit.lines self#engine) };
+      self#queue_draw) (Zed_edit.update engine [cursor]);
     self#on_event
       (function
          | LTerm_event.Key key -> begin
@@ -282,8 +286,32 @@ object(self)
          | _ ->
              false)
 
+  initializer scroll#set_document_size 
+    { cols = 0; rows = Zed_lines.count (Zed_edit.lines self#engine) }
+
+  val mutable size = { cols = 0; rows = 0 }
+  method! set_allocation rect =
+    size <- size_of_rect rect;
+    scroll#set_page_size size;
+    super#set_allocation rect
+
+  (* CR-someday jdimino for jdimino: add a way for a widget to tell
+     that it wants to expand as much as possible. *)
+  method size_request = { cols = 1_000_000; rows = 1_000_000 }
+
   val mutable shift = 0
   val mutable start = 0
+
+  initializer scroll#vscroll#on_offset_change (fun n  ->
+    start <- n;
+    let line_set = Zed_edit.lines engine in
+    let cursor_offset = Zed_cursor.get_position cursor in
+    let cursor_line = Zed_lines.line_index line_set cursor_offset in
+    if cursor_line < start then
+      Zed_edit.move_line context (start - cursor_line);
+    if cursor_line >= start + size.rows then
+      Zed_edit.move_line context (start + size.rows - 1 - cursor_line);
+    self#queue_draw)
 
   method draw ctx focused =
     let open LTerm_draw in

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -339,10 +339,6 @@ object(self)
     start <- 0; shift <- 0; start_line <- 0;
     self#update_window_position
 
-  (* CR-someday jdimino for jdimino: add a way for a widget to tell
-     that it wants to expand as much as possible. *)
-  method size_request = { cols = 1_000_000; rows = 1_000_000 }
-
   initializer vscroll#on_offset_change (fun n -> 
  
     (* find what line the cursor is currently on. *)

--- a/src/lTerm_edit.mli
+++ b/src/lTerm_edit.mli
@@ -70,6 +70,7 @@ val macro : action Zed_macro.t
     global one is used. *)
 class edit : ?clipboard : Zed_edit.clipboard -> ?macro : action Zed_macro.t -> unit -> object
   inherit LTerm_widget.t
+  inherit LTerm_widget.scrollable_document
 
   method engine : edit Zed_edit.t
     (** The edition engine used by this widget. *)

--- a/src/lTerm_edit.mli
+++ b/src/lTerm_edit.mli
@@ -74,12 +74,6 @@ class edit : ?clipboard : Zed_edit.clipboard -> ?macro : action Zed_macro.t -> u
   method engine : edit Zed_edit.t
     (** The edition engine used by this widget. *)
 
-  method start : int (* XXX delete me *)
-  method shift : int
-  method start_line : int
-  method offset_count : int
-  method delta : int
-
   method cursor : Zed_cursor.t
     (** The cursor used by this widget. *)
 

--- a/src/lTerm_edit.mli
+++ b/src/lTerm_edit.mli
@@ -70,10 +70,15 @@ val macro : action Zed_macro.t
     global one is used. *)
 class edit : ?clipboard : Zed_edit.clipboard -> ?macro : action Zed_macro.t -> unit -> object
   inherit LTerm_widget.t
-  inherit LTerm_widget.scrollable_document
 
   method engine : edit Zed_edit.t
     (** The edition engine used by this widget. *)
+
+  method start : int (* XXX delete me *)
+  method shift : int
+  method start_line : int
+  method offset_count : int
+  method delta : int
 
   method cursor : Zed_cursor.t
     (** The cursor used by this widget. *)
@@ -103,4 +108,7 @@ class edit : ?clipboard : Zed_edit.clipboard -> ?macro : action Zed_macro.t -> u
   method set_locale : string option -> unit
 
   method bind : LTerm_key.t list -> action list -> unit
+
+  method vscroll : LTerm_widget.scrollable
+
 end

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -173,8 +173,21 @@ class hscrollbar = LTerm_scroll_impl.hscrollbar
 class type scrollable_document = object
   method document_size : LTerm_geom.size
   method page_size : LTerm_geom.size
+  method voffset : int 
+  method hoffset : int 
   method set_voffset : int -> unit
   method set_hoffset : int -> unit
+end
+
+class virtual default_scrollable_document = object
+  method virtual document_size : LTerm_geom.size
+  method virtual page_size : LTerm_geom.size
+  val mutable voffset = 0
+  val mutable hoffset = 0
+  method voffset = voffset
+  method hoffset = hoffset
+  method set_voffset o = voffset <- o
+  method set_hoffset o = hoffset <- o 
 end
 
 class vscrollbar_for_document ?width (doc : #scrollable_document) = object(self)
@@ -198,6 +211,9 @@ class vscrollbar_for_document ?width (doc : #scrollable_document) = object(self)
     end
 
   method draw ctx focused = 
+    (if doc#voffset <> self#offset then 
+      self#set_offset doc#voffset; (* pick up offset from widget *) 
+      doc#set_voffset self#offset); (* in case the offset was clipped *)
     self#set_modes;
     super#draw ctx focused
 
@@ -224,6 +240,9 @@ class hscrollbar_for_document ?height (doc : #scrollable_document) = object(self
     end
 
   method draw ctx focused = 
+    (if doc#hoffset <> self#offset then 
+      self#set_offset doc#hoffset;
+      doc#set_hoffset self#offset);
     self#set_modes;
     super#draw ctx focused
 

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -148,6 +148,12 @@ class ['a] radiobutton = ['a] LTerm_buttons_impl.radiobutton
    +-----------------------------------------------------------------+ *)
 
 class type adjustment = LTerm_scroll_impl.adjustment
+(* XXX remove me *)
+class type scroll_debug = object
+  method debug_offset : int
+  method debug_size : int
+  method debug_steps : int
+end
 class vscrollbar = LTerm_scroll_impl.vscrollbar
 class hscrollbar = LTerm_scroll_impl.hscrollbar
 

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -229,6 +229,24 @@ class hscrollbar_for_document ?height (doc : #scrollable_document) = object(self
 
 end
 
+class vslider rng = object(self)
+  inherit vscrollbar ~rc:"slider" ~width:1 ()
+  method size_request = { rows=rng; cols=1 }
+  initializer
+    self#set_mouse_mode `middle;
+    self#set_scroll_bar_mode (`fixed 1);
+    range <- max 0 rng
+end
+
+class hslider rng = object(self)
+  inherit hscrollbar ~rc:"slider" ~height:1 ()
+  method size_request = { rows=1; cols=rng }
+  initializer
+    self#set_mouse_mode `middle;
+    self#set_scroll_bar_mode (`fixed 1);
+    range <- max 0 rng
+end
+
 (* +-----------------------------------------------------------------+
    | Running in a terminal                                           |
    +-----------------------------------------------------------------+ *)

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -161,9 +161,6 @@ class type scrollable_adjustment = object
   method set_max_scroll_bar_size : int -> unit
   method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch -> 
     (unit -> unit) -> unit
-  method scroll_event_handler : LTerm_event.t -> bool
-  method set_scroll_event_handler : (LTerm_event.t -> bool) -> unit
-  method add_scroll_event_handler : (LTerm_event.t -> bool) -> unit
 end
 
 class type scrollable_document = object
@@ -179,6 +176,11 @@ end
 class type scrollable_private = object
   method set_scroll_window_size : int -> unit
   method get_render_params : int * int * int
+end
+
+class type default_scroll_events = object
+  method mouse_event : LTerm_event.t -> bool
+  method scroll_key_event : LTerm_event.t -> bool
 end
 
 class scrollable = LTerm_scroll_impl.scrollable_adjustment

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -164,6 +164,7 @@ class hscrollbar = LTerm_scroll_impl.hscrollbar
 class type scrollable_document = object
   method set_document_size : LTerm_geom.size -> unit
   method set_page_size : LTerm_geom.size -> unit
+  method page : (unit -> unit) LTerm_geom.directions 
   method vscroll : scrollable_adjustment
   method hscroll : scrollable_adjustment
 end
@@ -193,6 +194,14 @@ class default_scrollable_document = object(self)
   method set_page_size size = 
     page_size <- size;
     self#update
+
+  method page = 
+    {
+      left  = (fun () -> hscroll#set_offset (hscroll#offset - page_size.cols));
+      right = (fun () -> hscroll#set_offset (hscroll#offset + page_size.cols));
+      up    = (fun () -> vscroll#set_offset (vscroll#offset - page_size.rows));
+      down  = (fun () -> vscroll#set_offset (vscroll#offset + page_size.rows));
+    }
 
   method vscroll = vscroll
   method hscroll = hscroll

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -85,7 +85,7 @@ class modal_frame = LTerm_containers_impl.modal_frame
    | Spacing for layout control (aka glue)                           |
    +-----------------------------------------------------------------+ *)
 
-class spacer ?(rows=0) ?(cols=0) () = object
+class spacing ?(rows=0) ?(cols=0) () = object
   inherit t "glue"
   val size_request = { rows; cols }
   method size_request = size_request

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -147,7 +147,7 @@ class ['a] radiobutton = ['a] LTerm_buttons_impl.radiobutton
    | Scrollbars                                                      |
    +-----------------------------------------------------------------+ *)
 
-class type scrollable = LTerm_scroll_impl.scrollable
+class type adjustment = LTerm_scroll_impl.adjustment
 class vscrollbar = LTerm_scroll_impl.vscrollbar
 class hscrollbar = LTerm_scroll_impl.hscrollbar
 

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -148,14 +148,69 @@ class ['a] radiobutton = ['a] LTerm_buttons_impl.radiobutton
    +-----------------------------------------------------------------+ *)
 
 class type adjustment = LTerm_scroll_impl.adjustment
+
 (* XXX remove me *)
 class type scroll_debug = object
   method debug_offset : int
   method debug_size : int
   method debug_steps : int
 end
+
+class type scrollbar = object
+  inherit t
+  inherit adjustment
+
+  method scroll_bar_size : int
+    (** size of scroll bar *)
+
+  method scroll_of_mouse : int -> int
+
+  method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+
+  method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
+
+  method set_min_scroll_bar_size : int -> unit
+
+  method set_max_scroll_bar_size : int -> unit
+
+  inherit scroll_debug
+
+end
+
 class vscrollbar = LTerm_scroll_impl.vscrollbar
 class hscrollbar = LTerm_scroll_impl.hscrollbar
+
+class vscrollbar_for_widget ?width document_size (widget : #t) = object
+  inherit vscrollbar ?width () as self
+
+  method size_request = { self#size_request with rows=widget#size_request.rows  } 
+
+  method set_allocation r = 
+    let size = size_of_rect r in
+    self#set_allocation r;
+    let window_size = size.rows in
+    let range = max 0 (document_size-window_size) in
+    self#set_range range;
+    self#set_mouse_mode `auto;
+    self#set_scroll_bar_mode (`dynamic window_size)
+
+end
+
+class hscrollbar_for_widget ?height document_size (widget : #t) = object
+  inherit hscrollbar ?height () as self
+
+  method size_request = { self#size_request with cols=widget#size_request.cols  } 
+
+  method set_allocation r = 
+    let size = size_of_rect r in
+    self#set_allocation r;
+    let window_size = size.cols in
+    let range = max 0 (document_size-window_size) in
+    self#set_range range;
+    self#set_mouse_mode `auto;
+    self#set_scroll_bar_mode (`dynamic window_size)
+
+end
 
 (* +-----------------------------------------------------------------+
    | Running in a terminal                                           |

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -154,7 +154,6 @@ class type scrollbar = object
   inherit adjustment
 
   method scroll_bar_size : int
-    (** size of scroll bar *)
 
   method scroll_of_mouse : int -> int
 
@@ -171,28 +170,26 @@ end
 class vscrollbar = LTerm_scroll_impl.vscrollbar
 class hscrollbar = LTerm_scroll_impl.hscrollbar
 
-class type scrollable_widget = object
-  inherit t
+class type scrollable_document = object
   method document_size : LTerm_geom.size
+  method page_size : LTerm_geom.size
   method set_voffset : int -> unit
   method set_hoffset : int -> unit
 end
 
-class vscrollbar_for_widget ?width (widget : #scrollable_widget) = object(self)
+class vscrollbar_for_document ?width (doc : #scrollable_document) = object(self)
   inherit vscrollbar ?width () as super
 
   initializer
-    super#on_offset_change widget#set_voffset
-
-  method size_request = { super#size_request with rows=widget#size_request.rows  } 
+    super#on_offset_change doc#set_voffset
 
   val mutable document_size : int = 0
   method private set_modes = 
-    let doc_size = widget#document_size.rows in
+    let doc_size = doc#document_size.rows in
     if doc_size <> document_size then begin
       document_size <- doc_size;
-      let window_size = (size_of_rect widget#allocation).rows in
-      let range = max 0 (document_size-window_size) in
+      let window_size = doc#page_size.rows in
+      let range = max 0 (document_size-window_size+1) in
       super#set_range range;
       super#set_mouse_mode `auto;
       super#set_scroll_bar_mode (`dynamic window_size)
@@ -204,21 +201,19 @@ class vscrollbar_for_widget ?width (widget : #scrollable_widget) = object(self)
 
 end
 
-class hscrollbar_for_widget ?height (widget : #scrollable_widget) = object(self)
+class hscrollbar_for_document ?height (doc : #scrollable_document) = object(self)
   inherit hscrollbar ?height () as super
 
   initializer
-    super#on_offset_change widget#set_hoffset
-
-  method size_request = { super#size_request with cols=widget#size_request.cols  } 
+    super#on_offset_change doc#set_hoffset
 
   val mutable document_size : int = 0
   method private set_modes = 
-    let doc_size = widget#document_size.cols in
+    let doc_size = doc#document_size.cols in
     if doc_size <> document_size then begin
       document_size <- doc_size;
-      let window_size = (size_of_rect widget#allocation).cols in
-      let range = max 0 (document_size-window_size) in
+      let window_size = doc#page_size.cols in
+      let range = max 0 (document_size-window_size+1) in
       super#set_range range;
       super#set_mouse_mode `auto;
       super#set_scroll_bar_mode (`dynamic window_size)

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -147,92 +147,46 @@ class ['a] radiobutton = ['a] LTerm_buttons_impl.radiobutton
    | Scrollbars                                                      |
    +-----------------------------------------------------------------+ *)
 
-class type adjustment = LTerm_scroll_impl.adjustment
+class adjustment = LTerm_scroll_impl.adjustment
 
-class type scrollable_adjustment = LTerm_scroll_impl.scrollable_adjustment
+(** Interface between an adjustment and a scrollbar widget. *)
+class type scrollable_adjustment = object
+  inherit adjustment
+  method incr : int
+  method decr : int
+  method mouse_scroll : int -> int
+  method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+  method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
+  method set_min_scroll_bar_size : int -> unit
+  method set_max_scroll_bar_size : int -> unit
+  method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch -> 
+    (unit -> unit) -> unit
+end
 
-class default_scrollable_adjustment = LTerm_scroll_impl.default_scrollable_adjustment
+class type scrollable_document = object
+  method page_size : int
+  method set_page_size : int -> unit
+  method document_size : int
+  method set_document_size : int -> unit
+  method page_next : int
+  method page_prev : int
+  method calculate_range : int -> int -> int
+end
 
-class vscrollbar_for_adjustment = LTerm_scroll_impl.vscrollbar_for_adjustment
+class type scrollable_private = object
+  method set_scroll_window_size : int -> unit
+  method get_render_params : int * int * int
+end
 
-class hscrollbar_for_adjustment = LTerm_scroll_impl.hscrollbar_for_adjustment
+class scrollable = LTerm_scroll_impl.scrollable_adjustment
 
 class vscrollbar = LTerm_scroll_impl.vscrollbar
 
 class hscrollbar = LTerm_scroll_impl.hscrollbar
 
-class type scrollable_document = object
-  method set_document_size : LTerm_geom.size -> unit
-  method set_page_size : LTerm_geom.size -> unit
-  method page : (unit -> unit) LTerm_geom.directions 
-  method vscroll : scrollable_adjustment
-  method hscroll : scrollable_adjustment
-end
+class vslider = LTerm_scroll_impl.vslider
 
-class default_scrollable_document = object(self)
- 
-  val mutable document_size = { rows=0; cols=0 }
-  val mutable page_size = { rows=0; cols=0 }
-
-  val vscroll = new default_scrollable_adjustment
-  val hscroll = new default_scrollable_adjustment
-
-  method private update = 
-    let range = max 0 (document_size.rows-page_size.rows+1) in
-    vscroll#set_range range;
-    vscroll#set_mouse_mode `auto;
-    vscroll#set_scroll_bar_mode (`dynamic page_size.rows);
-    let range = max 0 (document_size.cols-page_size.cols+1) in
-    hscroll#set_range range;
-    hscroll#set_mouse_mode `auto;
-    hscroll#set_scroll_bar_mode (`dynamic page_size.cols)
-
-  method set_document_size size = 
-    document_size <- size;
-    self#update
-
-  method set_page_size size = 
-    page_size <- size;
-    self#update
-
-  method page = 
-    {
-      left  = (fun () -> hscroll#set_offset (hscroll#offset - page_size.cols));
-      right = (fun () -> hscroll#set_offset (hscroll#offset + page_size.cols));
-      up    = (fun () -> vscroll#set_offset (vscroll#offset - page_size.rows));
-      down  = (fun () -> vscroll#set_offset (vscroll#offset + page_size.rows));
-    }
-
-  method vscroll = vscroll
-  method hscroll = hscroll
-
-end
-
-class vscrollbar_for_document ?width (doc : #scrollable_document) = object(self)
-  inherit vscrollbar_for_adjustment ?width doc#vscroll as super
-end
-
-class hscrollbar_for_document ?height (doc : #scrollable_document) = object(self)
-  inherit hscrollbar_for_adjustment ?height doc#hscroll as super
-end
-
-class vslider rng = object(self)
-  inherit vscrollbar ~rc:"slider" ~width:1 ()
-  initializer
-    self#set_mouse_mode `middle;
-    self#set_scroll_bar_mode (`fixed 1);
-    self#set_range (max 0 rng)
-  method size_request = { rows=rng; cols=1 }
-end
-
-class hslider rng = object(self)
-  inherit hscrollbar ~rc:"slider" ~height:1 ()
-  initializer
-    self#set_mouse_mode `middle;
-    self#set_scroll_bar_mode (`fixed 1);
-    self#set_range (max 0 rng)
-  method size_request = { rows=1; cols=rng }
-end
+class hslider = LTerm_scroll_impl.hslider
 
 (* +-----------------------------------------------------------------+
    | Running in a terminal                                           |

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -82,6 +82,16 @@ class frame = LTerm_containers_impl.frame
 class modal_frame = LTerm_containers_impl.modal_frame
 
 (* +-----------------------------------------------------------------+
+   | Spacing for layout control (aka glue)                           |
+   +-----------------------------------------------------------------+ *)
+
+class spacer ?(rows=0) ?(cols=0) () = object
+  inherit t "glue"
+  val size_request = { rows; cols }
+  method size_request = size_request
+end
+
+(* +-----------------------------------------------------------------+
    | Lines                                                           |
    +-----------------------------------------------------------------+ *)
 
@@ -132,6 +142,14 @@ class checkbutton = LTerm_buttons_impl.checkbutton
 class type ['a] radio = ['a] LTerm_buttons_impl.radio
 class ['a] radiogroup = ['a] LTerm_buttons_impl.radiogroup
 class ['a] radiobutton = ['a] LTerm_buttons_impl.radiobutton
+
+(* +-----------------------------------------------------------------+
+   | Scrollbars                                                      |
+   +-----------------------------------------------------------------+ *)
+
+class type scrollable = LTerm_scroll_impl.scrollable
+class vscrollbar = LTerm_scroll_impl.vscrollbar
+class hscrollbar = LTerm_scroll_impl.hscrollbar
 
 (* +-----------------------------------------------------------------+
    | Running in a terminal                                           |

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -161,6 +161,9 @@ class type scrollable_adjustment = object
   method set_max_scroll_bar_size : int -> unit
   method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch -> 
     (unit -> unit) -> unit
+  method scroll_event_handler : LTerm_event.t -> bool
+  method set_scroll_event_handler : (LTerm_event.t -> bool) -> unit
+  method add_scroll_event_handler : (LTerm_event.t -> bool) -> unit
 end
 
 class type scrollable_document = object

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -183,16 +183,18 @@ class vscrollbar_for_document ?width (doc : #scrollable_document) = object(self)
   initializer
     super#on_offset_change doc#set_voffset
 
-  val mutable document_size : int = 0
+  val mutable document_size = 0
+  val mutable page_size = 0
   method private set_modes = 
-    let doc_size = doc#document_size.rows in
-    if doc_size <> document_size then begin
-      document_size <- doc_size;
-      let window_size = doc#page_size.rows in
-      let range = max 0 (document_size-window_size+1) in
+    let document_size' = doc#document_size.rows in
+    let page_size' = doc#page_size.rows in
+    if document_size' <> document_size || page_size' <> page_size then begin
+      document_size <- document_size';
+      page_size <- page_size';
+      let range = max 0 (document_size-page_size+1) in
       super#set_range range;
       super#set_mouse_mode `auto;
-      super#set_scroll_bar_mode (`dynamic window_size)
+      super#set_scroll_bar_mode (`dynamic page_size)
     end
 
   method draw ctx focused = 
@@ -207,16 +209,18 @@ class hscrollbar_for_document ?height (doc : #scrollable_document) = object(self
   initializer
     super#on_offset_change doc#set_hoffset
 
-  val mutable document_size : int = 0
+  val mutable document_size = 0
+  val mutable page_size = 0
   method private set_modes = 
-    let doc_size = doc#document_size.cols in
-    if doc_size <> document_size then begin
-      document_size <- doc_size;
-      let window_size = doc#page_size.cols in
-      let range = max 0 (document_size-window_size+1) in
+    let document_size' = doc#document_size.cols in
+    let page_size' = doc#page_size.cols in
+    if document_size' <> document_size || page_size' <> page_size then begin
+      document_size <- document_size';
+      page_size <- page_size';
+      let range = max 0 (document_size-page_size+1) in
       super#set_range range;
       super#set_mouse_mode `auto;
-      super#set_scroll_bar_mode (`dynamic window_size)
+      super#set_scroll_bar_mode (`dynamic page_size)
     end
 
   method draw ctx focused = 

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -174,10 +174,15 @@ class hscrollbar = LTerm_scroll_impl.hscrollbar
 class type scrollable_widget = object
   inherit t
   method document_size : LTerm_geom.size
+  method set_voffset : int -> unit
+  method set_hoffset : int -> unit
 end
 
 class vscrollbar_for_widget ?width (widget : #scrollable_widget) = object(self)
   inherit vscrollbar ?width () as super
+
+  initializer
+    super#on_offset_change widget#set_voffset
 
   method size_request = { super#size_request with rows=widget#size_request.rows  } 
 
@@ -201,6 +206,9 @@ end
 
 class hscrollbar_for_widget ?height (widget : #scrollable_widget) = object(self)
   inherit hscrollbar ?height () as super
+
+  initializer
+    super#on_offset_change widget#set_hoffset
 
   method size_request = { super#size_request with cols=widget#size_request.cols  } 
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -351,12 +351,27 @@ class type scrollable_document = object
   method page_size : LTerm_geom.size
     (** Size of a page *)
 
+  method voffset : int
+    (** Get vertical offset *)
+
+  method hoffset : int
+    (** Get horizontal offset *)
+
   method set_voffset : int -> unit
     (** Set vertical offset *)
 
   method set_hoffset : int -> unit
     (** Set horizontal offset *)
 
+end
+
+class virtual default_scrollable_document : object
+  method virtual document_size : LTerm_geom.size
+  method virtual page_size : LTerm_geom.size
+  method voffset : int
+  method hoffset : int
+  method set_voffset : int -> unit
+  method set_hoffset : int -> unit
 end
 
 (** Vertical scrollbar for scrollable widgets *)

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -330,15 +330,6 @@ class type scrollable_adjustment = object
     (** [on_scrollbar_change ?switch f] calls f when the scrollbar is changed and
      needs to be re-drawn. *)
 
-  method scroll_event_handler : LTerm_event.t -> bool
-    (** event handlers run by the scrollbar widget *)
-
-  method set_scroll_event_handler : (LTerm_event.t -> bool) -> unit
-    (** set event handler *)
-
-  method add_scroll_event_handler : (LTerm_event.t -> bool) -> unit
-    (** add event handlers *)
-
 end
 
 (* Automatic configuration of the scrollbar.
@@ -396,22 +387,39 @@ class scrollable : object
   inherit scrollable_private
 end
 
+class type default_scroll_events = object
+  method mouse_event : LTerm_event.t -> bool
+  method scroll_key_event : LTerm_event.t -> bool
+end
+
 (** Vertical scrollbar. *)
-class vscrollbar : ?rc:string -> ?width:int -> #scrollable -> t
+class vscrollbar : 
+  ?rc:string -> ?default_event_handler:bool -> ?width:int -> 
+  #scrollable -> object
+  inherit t
+  inherit default_scroll_events
+end
 
 (** Horizontal scrollbar. *)
-class hscrollbar : ?rc:string -> ?height:int -> #scrollable -> t
+class hscrollbar : 
+  ?rc:string -> ?default_event_handler:bool -> ?height:int -> 
+  #scrollable -> object
+  inherit t
+  inherit default_scroll_events
+end
 
 (** Vertical slider *)
 class vslider : int -> object
   inherit t
   inherit adjustment
+  inherit default_scroll_events
 end
 
 (** Horizontal slider *)
 class hslider : int -> object
   inherit t
   inherit adjustment
+  inherit default_scroll_events
 end
 
 (** {6 Running in a terminal} *)

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -289,9 +289,13 @@ class type adjustment = object
   method decr : unit
     (** decrement offset by one step *)
 
-  method scroll_bar_size : int
-    (** size of scroll bar *)
+end
 
+(* XXX remove me *)
+class type scroll_debug = object
+  method debug_offset : int
+  method debug_size : int
+  method debug_steps : int
 end
 
 class vscrollbar : 
@@ -299,6 +303,14 @@ class vscrollbar :
   object
     inherit t
     inherit adjustment
+
+    method scroll_bar_size : int
+      (** size of scroll bar *)
+
+    method set_mouse_mode : [`ratio|`middle|`left|`right] -> unit
+
+    inherit scroll_debug
+
   end
 
 class hscrollbar : 
@@ -306,6 +318,14 @@ class hscrollbar :
   object
     inherit t
     inherit adjustment
+
+    method scroll_bar_size : int
+      (** size of scroll bar *)
+
+    method set_mouse_mode : [`ratio|`middle|`left|`right] -> unit
+
+    inherit scroll_debug
+
   end
 
 (** {6 Running in a terminal} *)

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -301,37 +301,33 @@ class type scroll_debug = object
   method debug_steps : int
 end
 
-class vscrollbar : ?width:int -> unit ->
-  object
-    inherit t
-    inherit adjustment
+class type scrollbar = object
+  inherit t
+  inherit adjustment
 
-    method scroll_bar_size : int
-      (** size of scroll bar *)
+  method scroll_bar_size : int
+    (** size of scroll bar *)
 
-    method set_mouse_mode : [`middle | `ratio] -> unit
+  method scroll_of_mouse : int -> int
+    (** convert mouse coord to a scroll offset *)
 
-    method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+  method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
 
-    inherit scroll_debug
+  method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
 
-  end
+  method set_min_scroll_bar_size : int -> unit
 
-class hscrollbar : ?height:int -> unit ->
-  object
-    inherit t
-    inherit adjustment
+  method set_max_scroll_bar_size : int -> unit
 
-    method scroll_bar_size : int
-      (** size of scroll bar *)
+  inherit scroll_debug
 
-    method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+end
 
-    method set_mouse_mode : [`middle | `ratio] -> unit
+class vscrollbar : ?width:int -> unit -> scrollbar
+class hscrollbar : ?height:int -> unit -> scrollbar
 
-    inherit scroll_debug
-
-  end
+class vscrollbar_for_widget : ?width:int -> int -> #t -> scrollbar
+class hscrollbar_for_widget : ?height:int -> int -> #t -> scrollbar
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -258,28 +258,41 @@ end
 
 (** {6 Scrollbars} *)
 
-(** methods required for a widget to supprt scrollbars *)
-class type scrollable = object
-  method full_size : LTerm_geom.size
-    (* full size of scrollable window *)
+(** Adjustable integer value from (0..range-1) *)
+class type adjustment = object
 
-  method offset : LTerm_geom.coord
-    (* offset within window *)
-  
-  method set_offset : LTerm_geom.coord -> unit
-    (* set offset within window *)
+  method range : int
+    (** range of adjustment *)
+
+  method set_range : int -> unit
+    (** set range of adjustment *)
+
+  method offset : int
+    (** offset from (0..range-1) *)
+
+  method set_offset : int -> unit
+    (** set offset clipped to range *)
+
+  method incr : unit
+    (** increment offset by one step *)
+
+  method decr : unit
+    (** decrement offset by one step *)
+
+  method scroll_bar_size : int
+    (** size of scroll bar *)
 
 end
 
-(** vertical scrollbar *)
-class vscrollbar : 
-  ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
-  scrollable:#scrollable -> t
+class vscrollbar : ?size_request:LTerm_geom.size -> unit -> object
+  inherit t
+  inherit adjustment
+end
 
-(** horizontal scrollbar *)
-class hscrollbar : 
-  ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
-  scrollable:#scrollable -> t
+class hscrollbar : ?size_request:LTerm_geom.size -> unit -> object
+  inherit t
+  inherit adjustment
+end
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -337,10 +337,10 @@ class type scrollbar = object
 end
 
 (** Vertically oriented scrollbar *)
-class vscrollbar : ?width:int -> unit -> scrollbar
+class vscrollbar : ?rc:string -> ?width:int -> unit -> scrollbar
 
 (** Horizontally oriented scrollbar *)
-class hscrollbar : ?height:int -> unit -> scrollbar
+class hscrollbar : ?rc:string -> ?height:int -> unit -> scrollbar
 
 (** Type of widget containing a scrollable document *)
 class type scrollable_document = object
@@ -364,6 +364,12 @@ class vscrollbar_for_document : ?width:int -> #scrollable_document -> scrollbar
 
 (** Horizontal scrollbar for scrollable widgets *)
 class hscrollbar_for_document : ?height:int -> #scrollable_document -> scrollbar
+
+(** Vertical slider *)
+class vslider : int -> scrollbar
+
+(** Horizontal slider *)
+class hslider : int -> scrollbar
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -345,8 +345,16 @@ class hscrollbar : ?height:int -> unit -> scrollbar
 (** Type of widget containing a scrollable document *)
 class type scrollable_widget = object
   inherit t
+
   method document_size : LTerm_geom.size
     (** Size of the document *)
+
+  method set_voffset : int -> unit
+    (** Set vertical offset *)
+
+  method set_hoffset : int -> unit
+    (** Set horizontal offset *)
+
 end
 
 (** Vertical scrollbar for scrollable widgets *)

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -265,16 +265,26 @@ class type adjustment = object
     (** range of adjustment *)
 
   method set_range : int -> unit
-    (** set range of adjustment *)
+    (** set range of adjustment.
+    
+     The range can be changed dynamically, set statically in an
+     [initializer] if known when the widget is created,
+     or set in the [set_allocation] method if the size of the 
+     widget needs to be known. *)
 
   method offset : int
     (** offset from (0..range-1) *)
 
   method set_offset : int -> unit
-    (** set offset clipped to range *)
+    (** Set offset clipped to range.
+    
+    The scrollbars will call [queue_draw] when [set_offset]
+    is called. *)
 
   method incr : unit
-    (** increment offset by one step *)
+    (** increment offset by one step 
+    
+    If range > number of scroll bar steps then step>=1. *)
 
   method decr : unit
     (** decrement offset by one step *)
@@ -284,15 +294,19 @@ class type adjustment = object
 
 end
 
-class vscrollbar : ?size_request:LTerm_geom.size -> unit -> object
-  inherit t
-  inherit adjustment
-end
+class vscrollbar : 
+  ?size_request:LTerm_geom.size -> ?default_scroll_bar_size:int -> unit ->
+  object
+    inherit t
+    inherit adjustment
+  end
 
-class hscrollbar : ?size_request:LTerm_geom.size -> unit -> object
-  inherit t
-  inherit adjustment
-end
+class hscrollbar : 
+  ?size_request:LTerm_geom.size -> ?default_scroll_bar_size:int -> unit ->
+  object
+    inherit t
+    inherit adjustment
+  end
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -281,6 +281,9 @@ class type adjustment = object
     The scrollbars will call [queue_draw] when [set_offset]
     is called. *)
 
+  method on_offset_change : ?switch:LTerm_widget_callbacks.switch -> 
+     (int -> unit) -> unit
+
   method incr : unit
     (** increment offset by one step 
     
@@ -298,8 +301,7 @@ class type scroll_debug = object
   method debug_steps : int
 end
 
-class vscrollbar : 
-  ?size_request:LTerm_geom.size -> ?default_scroll_bar_size:int -> unit ->
+class vscrollbar : ?width:int -> unit ->
   object
     inherit t
     inherit adjustment
@@ -307,14 +309,15 @@ class vscrollbar :
     method scroll_bar_size : int
       (** size of scroll bar *)
 
-    method set_mouse_mode : [`ratio|`middle|`left|`right] -> unit
+    method set_mouse_mode : [`middle | `ratio] -> unit
+
+    method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
 
     inherit scroll_debug
 
   end
 
-class hscrollbar : 
-  ?size_request:LTerm_geom.size -> ?default_scroll_bar_size:int -> unit ->
+class hscrollbar : ?height:int -> unit ->
   object
     inherit t
     inherit adjustment
@@ -322,7 +325,9 @@ class hscrollbar :
     method scroll_bar_size : int
       (** size of scroll bar *)
 
-    method set_mouse_mode : [`ratio|`middle|`left|`right] -> unit
+    method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+
+    method set_mouse_mode : [`middle | `ratio] -> unit
 
     inherit scroll_debug
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -343,11 +343,13 @@ class vscrollbar : ?width:int -> unit -> scrollbar
 class hscrollbar : ?height:int -> unit -> scrollbar
 
 (** Type of widget containing a scrollable document *)
-class type scrollable_widget = object
-  inherit t
+class type scrollable_document = object
 
   method document_size : LTerm_geom.size
     (** Size of the document *)
+
+  method page_size : LTerm_geom.size
+    (** Size of a page *)
 
   method set_voffset : int -> unit
     (** Set vertical offset *)
@@ -358,10 +360,10 @@ class type scrollable_widget = object
 end
 
 (** Vertical scrollbar for scrollable widgets *)
-class vscrollbar_for_widget : ?width:int -> #scrollable_widget -> scrollbar
+class vscrollbar_for_document : ?width:int -> #scrollable_document -> scrollbar
 
 (** Horizontal scrollbar for scrollable widgets *)
-class hscrollbar_for_widget : ?height:int -> #scrollable_widget -> scrollbar
+class hscrollbar_for_document : ?height:int -> #scrollable_document -> scrollbar
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -283,6 +283,7 @@ class type adjustment = object
 
   method on_offset_change : ?switch:LTerm_widget_callbacks.switch -> 
      (int -> unit) -> unit
+    (** [on_offset_change ?switch f] calls f when the offset changes. *)
 
   method incr : unit
     (** increment offset by one step 
@@ -294,40 +295,65 @@ class type adjustment = object
 
 end
 
-(* XXX remove me *)
-class type scroll_debug = object
-  method debug_offset : int
-  method debug_size : int
-  method debug_steps : int
-end
-
 class type scrollbar = object
   inherit t
   inherit adjustment
 
   method scroll_bar_size : int
-    (** size of scroll bar *)
+    (** Size of scroll bar *)
 
   method scroll_of_mouse : int -> int
-    (** convert mouse coord to a scroll offset *)
+    (** Convert mouse coord to a scroll offset *)
 
   method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+    (** Configure how the size of the scrollbar is calculated.
+
+     [`fixed x] sets the size to x.
+
+     [`dynamic 0] sets the size to reflect the ratio between 
+     the range and scroll window size.
+
+     [`dynamic x] (x>0) interprets [x] as the size of the view and
+     sets the size of the scroll bar to reflect the amount of
+     content displayed. *)
 
   method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
+    (** Configure how a mouse coordinate is converted to a scroll bar offest.
+     
+     [`middle] sets the middle of the scrollbar to the position clicked.
+
+     [`ratio] computes the offset relative to the scroll bar and scroll window sizes,
+     with a 10% deadzone at the extremities.
+
+     [`auto] chooses [`middle] mode if the scroll bar size is less than half the window
+     size and [`ratio] otherwise. *)
 
   method set_min_scroll_bar_size : int -> unit
+    (** Set the minimum scroll bar size (default:1) *)
 
   method set_max_scroll_bar_size : int -> unit
-
-  inherit scroll_debug
+    (** Set the maximum scroll bar size (default: scroll window size *)
 
 end
 
+(** Vertically oriented scrollbar *)
 class vscrollbar : ?width:int -> unit -> scrollbar
+
+(** Horizontally oriented scrollbar *)
 class hscrollbar : ?height:int -> unit -> scrollbar
 
-class vscrollbar_for_widget : ?width:int -> int -> #t -> scrollbar
-class hscrollbar_for_widget : ?height:int -> int -> #t -> scrollbar
+(** Type of widget containing a scrollable document *)
+class type scrollable_widget = object
+  inherit t
+  method document_size : LTerm_geom.size
+    (** Size of the document *)
+end
+
+(** Vertical scrollbar for scrollable widgets *)
+class vscrollbar_for_widget : ?width:int -> #scrollable_widget -> scrollbar
+
+(** Horizontal scrollbar for scrollable widgets *)
+class hscrollbar_for_widget : ?height:int -> #scrollable_widget -> scrollbar
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -153,7 +153,7 @@ class modal_frame : object
 end
 
 (** A widget used for layout control within boxes *)
-class spacer : ?rows:int -> ?cols:int -> unit -> t
+class spacing : ?rows:int -> ?cols:int -> unit -> t
 
 (** {6 Lines} *)
 
@@ -258,19 +258,28 @@ end
 
 (** {6 Scrollbars} *)
 
+(** methods required for a widget to supprt scrollbars *)
 class type scrollable = object
   method full_size : LTerm_geom.size
+    (* full size of scrollable window *)
+
   method offset : LTerm_geom.coord
+    (* offset within window *)
+  
   method set_offset : LTerm_geom.coord -> unit
+    (* set offset within window *)
+
 end
 
+(** vertical scrollbar *)
 class vscrollbar : 
   ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
-  scrollable:scrollable -> t
+  scrollable:#scrollable -> t
 
+(** horizontal scrollbar *)
 class hscrollbar : 
   ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
-  scrollable:scrollable -> t
+  scrollable:#scrollable -> t
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -330,6 +330,15 @@ class type scrollable_adjustment = object
     (** [on_scrollbar_change ?switch f] calls f when the scrollbar is changed and
      needs to be re-drawn. *)
 
+  method scroll_event_handler : LTerm_event.t -> bool
+    (** event handlers run by the scrollbar widget *)
+
+  method set_scroll_event_handler : (LTerm_event.t -> bool) -> unit
+    (** set event handler *)
+
+  method add_scroll_event_handler : (LTerm_event.t -> bool) -> unit
+    (** add event handlers *)
+
 end
 
 (* Automatic configuration of the scrollbar.

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -152,6 +152,9 @@ class modal_frame : object
   inherit frame
 end
 
+(** A widget used for layout control within boxes *)
+class spacer : ?rows:int -> ?cols:int -> unit -> t
+
 (** {6 Lines} *)
 
 (** A horizontal line. *)
@@ -252,6 +255,22 @@ class ['a] radiobutton : 'a radiogroup -> string -> 'a -> object
    to use {!radiogroup.on_state_change} instead. *)
 
 end
+
+(** {6 Scrollbars} *)
+
+class type scrollable = object
+  method full_size : LTerm_geom.size
+  method offset : LTerm_geom.coord
+  method set_offset : LTerm_geom.coord -> unit
+end
+
+class vscrollbar : 
+  ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
+  scrollable:scrollable -> t
+
+class hscrollbar : 
+  ?scroll_bar_size:int -> ?scroll_window_size:int -> ?scroll_bar_thickness:int ->
+  scrollable:scrollable -> t
 
 (** {6 Running in a terminal} *)
 

--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -381,18 +381,46 @@ class type scrollable_private = object
 
 end
 
+(** Main object implementing scroll logic for coordination 
+ between a scrollable wigdet and a scrollbar widget.
+
+ [scrollable_adjustment] implements the main logic and provides a
+ lowlevel interface for controlling how mouse events are translated
+ to scroll offsets ([set_mouse_mode]) and the size of the scrollbar 
+ ([set_scroll_bar_mode]).
+
+ [scrollable_document] provides a higher level interface for 
+ configuring the operation of the scrollbar where the scrollbar
+ is used to reflect the area of a page within a potentially larger
+ document.
+
+ [scrollbar_private] is an internal interface between the [scrollable]
+ object and a [scrollbar] used to exchange parameters needed to
+ perform rendering. *)
 class scrollable : object
   inherit scrollable_adjustment
   inherit scrollable_document
   inherit scrollable_private
 end
 
+(** Events exposed by scrollbar widgets.  These may be applied to
+ other widgets if required. *)
 class type default_scroll_events = object
   method mouse_event : LTerm_event.t -> bool
   method scroll_key_event : LTerm_event.t -> bool
 end
 
-(** Vertical scrollbar. *)
+(** Vertical scrollbar widget. 
+ 
+ [rc] is the resource class of the widget.  [".(un)focused"] sets the
+ (un)focused style of the widget.  [".barstyle"] can be [filled] or 
+ [outline].  [".track"] is a bool to display a central track line.
+
+ [default_event_handler] when true (the default) installs the 
+ [mouse_event] and [scroll_key_event] handlers.
+ 
+ [width] (resp. [height]) defines the prefered thickness of the
+ scrollbar. *)
 class vscrollbar : 
   ?rc:string -> ?default_event_handler:bool -> ?width:int -> 
   #scrollable -> object
@@ -400,7 +428,7 @@ class vscrollbar :
   inherit default_scroll_events
 end
 
-(** Horizontal scrollbar. *)
+(** Horizontal scrollbar widget. *)
 class hscrollbar : 
   ?rc:string -> ?default_event_handler:bool -> ?height:int -> 
   #scrollable -> object
@@ -408,14 +436,14 @@ class hscrollbar :
   inherit default_scroll_events
 end
 
-(** Vertical slider *)
+(** Vertical slider widget. *)
 class vslider : int -> object
   inherit t
   inherit adjustment
   inherit default_scroll_events
 end
 
-(** Horizontal slider *)
+(** Horizontal slider widget. *)
 class hslider : int -> object
   inherit t
   inherit adjustment

--- a/src/widget_impl/lTerm_buttons_impl.ml
+++ b/src/widget_impl/lTerm_buttons_impl.ml
@@ -82,17 +82,21 @@ class checkbutton initial_label initial_state = object(self)
   val mutable state = initial_state
 
   initializer
-    self#on_event
-    (function
-      | LTerm_event.Key { control = false; meta = false; shift = false; code }
-        when (code = Enter || code = space) ->
-          state <- not state;
-          (* checkbutton changes the state when clicked, so has to be redrawn *)
-          self#queue_draw;
-          exec_callbacks click_callbacks ();
-          true
-      | _ ->
-          false);
+    self#on_event (fun ev ->
+      let update () = 
+        state <- not state;
+        (* checkbutton changes the state when clicked, so has to be redrawn *)
+        self#queue_draw;
+        exec_callbacks click_callbacks ();
+        true
+      in
+      match ev with 
+        | LTerm_event.Key { control = false; meta = false; shift = false; code }
+          when (code = Enter || code = space) -> update ()
+        | LTerm_event.Mouse m 
+          when m.button = Button1 && in_rect self#allocation (coord m) -> update ()
+        | _ ->
+            false);
     self#set_resource_class "checkbutton"
 
   method state = state

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -3,66 +3,6 @@ open LTerm_geom
 
 class t = LTerm_widget_base_impl.t
 
-module Proj = struct
-
-  let create range1 range2 = 
-    assert (range1 >= range2);
-    let range1' = float_of_int range1 in
-    let range2' = float_of_int (range2-1) in
-    Array.init range2 
-      (fun i ->
-        let i' = float_of_int i in
-        max 0 (min range1 
-          (int_of_float @@ ((range1' *. i' /. range2') +. 0.5))))
-  
-  let scale_up t offset = 
-    t.(max 0 (min offset (Array.length t - 1)))
-
-  let scale_down a value = 
-    let (<:) x y = scale_up a x < y in
-    let (>:) x y = scale_up a x > y in
-    let (-:) x y = scale_up a x - y in
-    (* binary search nearest *)
-    let rec search low high =
-      if high = low then low 
-      else if high = low + 1 then
-        if abs (low -: value) < abs (high -: value) then low 
-        else high
-      else 
-        let mid = (low + high) / 2 in
-        if mid >: value then search low mid
-        else if mid <: value then search mid high
-        else mid 
-    in
-    let len = Array.length a in
-    if value < 0 then 0
-    else if (len-1) <: value then len-1
-    else search 0 (len - 1)
-
-  let make () = 
-    let range1', range2' = ref 0, ref 0 in
-    let proj = ref [||] in
-    let memo_create range1 range2 = 
-      if !range1' = range1 && !range2' = range2 then !proj
-      else begin
-        proj := create range1 range2;
-        range1' := range1;
-        range2' := range2;
-        !proj
-      end
-    in
-    let scale_to range1 range2 = 
-      if range1 >= range2 then scale_up (memo_create range1 range2)
-      else scale_down (memo_create range2 range1)
-    in
-    let scale_from range1 range2 = 
-      if range1 >= range2 then scale_down (memo_create range1 range2)
-      else scale_up (memo_create range2 range1)
-    in
-    scale_to, scale_from
-
-end
-
 let hbar = 0x2550
 let vbar = 0x2551
 let lbar = 0x2560
@@ -71,34 +11,31 @@ let tbar = 0x2566
 let bbar = 0x2569
 let xbar = 0x256c
 
-class type scrollable = object
-
-  method full_size : size
-    (* full size of scrollable window *)
-
-  method offset : coord
-    (* offset within window *)
-
-  method set_offset : coord -> unit
-    (* set offset within window *)
-
+class type adjustment = object
+  method range : int
+  method set_range : int -> unit
+  method offset : int
+  method set_offset : int -> unit
+  method incr : unit
+  method decr : unit
+  method scroll_bar_size : int
 end
 
-class virtual scrollbar ~scroll_bar_size ~(scrollable:#scrollable) =
-  let window_of_scroll, scroll_of_window = Proj.make () in
-
+class virtual scrollbar = 
+  let map_range range1 range2 offset1 = 
+    let map_range range1 range2 offset1 = 
+      max 0. (min range2 (range2 *. offset1 /. range1)) 
+    in
+    let rnd x = int_of_float (x +. 0.5) in
+    rnd @@ map_range 
+      (float_of_int range1)
+      (float_of_int range2)
+      (float_of_int offset1)
+  in
   object(self)
     inherit t "scrollbar"
 
     method can_focus = true
-
-    method virtual private dim_of_coord : coord -> int
-    method virtual private dim_of_size : size -> int
-    method virtual private dim_of_rect : rect -> int
-    method virtual private mouse_offset : LTerm_mouse.t -> rect -> int
-    method virtual private update_dim : coord -> int -> coord
-    method virtual private key_scroll_incr : LTerm_key.code
-    method virtual private key_scroll_decr : LTerm_key.code
 
     val mutable focused_style = LTerm_style.none
     val mutable unfocused_style = LTerm_style.none
@@ -107,70 +44,84 @@ class virtual scrollbar ~scroll_bar_size ~(scrollable:#scrollable) =
       focused_style <- LTerm_resources.get_style (rc ^ ".focused") resources;
       unfocused_style <- LTerm_resources.get_style (rc ^ ".unfocused") resources
 
-    method private window_size = self#dim_of_size scrollable#full_size 
-    method private scroll_steps = self#dim_of_rect self#allocation - scroll_bar_size + 1 
+    val mutable range = 0
+    val mutable offset = 0
+    method range = range
+    method set_range r = range <- max 0 r
+    method offset = offset
+    method set_offset o = offset <- max 0 (min (range-1) o); self#queue_draw
+    method scroll_bar_size = 5
+
+    method virtual private mouse_offset : LTerm_mouse.t -> rect -> int
+    method virtual private key_scroll_incr : LTerm_key.code
+    method virtual private key_scroll_decr : LTerm_key.code
+    method virtual private scroll_window_size : int
+
+    method private scroll_bar_steps = 
+      self#scroll_window_size - self#scroll_bar_size + 1
 
     val mutable scroll_bar_offset = 0
+    method private set_scroll_bar_offset o = 
+      scroll_bar_offset <- max 0 (min (self#scroll_bar_steps-1) o)
 
     method private window_of_scroll offset = 
-      scroll_bar_offset <- max 0 (min (self#scroll_steps - 1) offset);
-      window_of_scroll self#window_size self#scroll_steps offset
+      self#set_scroll_bar_offset offset;
+      map_range (self#scroll_bar_steps-1) (range-1) scroll_bar_offset
 
     method private scroll_of_window offset = 
-      let o = scroll_of_window self#window_size self#scroll_steps offset in
-      scroll_bar_offset <- max 0 (min (self#scroll_steps - 1) o);
-      o
+      let offset = map_range (range-1) (self#scroll_bar_steps-1) offset in
+      self#set_scroll_bar_offset offset;
+      scroll_bar_offset
 
-    initializer self#on_event @@ fun ev ->
-      let open LTerm_mouse in
-      let open LTerm_key in
+    method incr = 
+      if range >= self#scroll_bar_steps then
+        self#set_offset @@ self#window_of_scroll (scroll_bar_offset+1) 
+      else
+        self#set_offset (self#offset+1);
 
-      let alloc = self#allocation in
-      let prev () = self#window_of_scroll (scroll_bar_offset - 1) in
-      let next () = self#window_of_scroll (scroll_bar_offset + 1) in
-      let to_ofs x = self#update_dim scrollable#offset x in
+    method decr = 
+      if range >= self#scroll_bar_steps then
+        self#set_offset @@ self#window_of_scroll (scroll_bar_offset-1) 
+      else
+        self#set_offset (self#offset-1);
 
-      match ev with
-      | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
-        let scroll = self#mouse_offset m alloc in
-        scrollable#set_offset @@ to_ofs @@ self#window_of_scroll scroll;
-        self#queue_draw;
-        true
+  initializer self#on_event @@ fun ev ->
+    let open LTerm_mouse in
+    let open LTerm_key in
 
-      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
-        when code=self#key_scroll_decr ->
-        scrollable#set_offset @@ to_ofs (prev ());
-        self#queue_draw;
-        true
+    let alloc = self#allocation in
 
-      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
-        when code=self#key_scroll_incr ->
-        scrollable#set_offset @@ to_ofs (next ());
-        self#queue_draw;
-        true
+    match ev with
+    | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
+      let scroll = self#mouse_offset m alloc in
+      self#set_offset @@ self#window_of_scroll scroll;
+      true
 
-      | _ -> false
+    | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+      when code=self#key_scroll_decr ->
+      self#decr;
+      true
+
+    | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+      when code=self#key_scroll_incr ->
+      self#incr;
+      true
+
+    | _ -> false
 
   end
 
-class vscrollbar
-  ?(scroll_bar_size=5) 
-  ?(scroll_window_size=0) 
-  ?(scroll_bar_thickness=2) 
-  ~scrollable = object(self)
-  inherit scrollbar ~scroll_bar_size ~scrollable 
+class vscrollbar ?size_request () = object(self)
+  inherit scrollbar
 
-  method size_request = { rows=scroll_window_size; cols=scroll_bar_thickness }
+  method size_request = 
+    match size_request with None -> { rows=0; cols=2 } | Some(x) -> x
 
-  method private dim_of_coord = row
-  method private dim_of_size = rows
-  method private dim_of_rect r = r.row2 - r.row1
   method private mouse_offset m alloc = m.LTerm_mouse.row - alloc.row1 
-  method private update_dim c row = { c with LTerm_geom.row }
   method private key_scroll_incr = LTerm_key.Down
   method private key_scroll_decr = LTerm_key.Up
+  method private scroll_window_size = self#allocation.row2 - self#allocation.row1
 
-  (* ...should try and refactor this into the base class... *)
   method draw ctx focused = 
     let focus = (self :> t) = focused in
     let { cols; _ } = LTerm_draw.size ctx in
@@ -178,11 +129,11 @@ class vscrollbar
     let style = if focus then focused_style else unfocused_style in
     LTerm_draw.fill_style ctx style;
 
-    let offset = self#scroll_of_window @@ self#dim_of_coord scrollable#offset in
+    let offset = self#scroll_of_window @@ self#offset in
 
     for col=0 to cols-1 do
       let r1 = offset in
-      let r2 = offset + scroll_bar_size-1 in
+      let r2 = offset + self#scroll_bar_size-1 in
       for row=r1 to r2 do
         if col=0 || col=cols-1 then
           if row=r1 && row=r2 then
@@ -197,25 +148,18 @@ class vscrollbar
           LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int hbar
       done
     done
-
 end
 
-class hscrollbar
-  ?(scroll_bar_size=5) 
-  ?(scroll_window_size=0) 
-  ?(scroll_bar_thickness=2) 
-  ~scrollable = object(self)
-  inherit scrollbar ~scroll_bar_size ~scrollable 
+class hscrollbar ?size_request () = object(self)
+  inherit scrollbar
+  
+  method size_request = 
+    match size_request with None -> { rows=2; cols=0 } | Some(x) -> x
 
-  method size_request = { cols=scroll_window_size; rows=scroll_bar_thickness }
-
-  method private dim_of_coord = col
-  method private dim_of_size = cols
-  method private dim_of_rect r = r.col2 - r.col1
   method private mouse_offset m alloc = m.LTerm_mouse.col - alloc.col1 
-  method private update_dim c col = { c with LTerm_geom.col }
   method private key_scroll_incr = LTerm_key.Right
   method private key_scroll_decr = LTerm_key.Left
+  method private scroll_window_size = self#allocation.col2 - self#allocation.col1
 
   method draw ctx focused = 
     let focus = (self :> t) = focused in
@@ -224,10 +168,10 @@ class hscrollbar
     let style = if focus then focused_style else unfocused_style in
     LTerm_draw.fill_style ctx style;
 
-    let offset = self#scroll_of_window @@ self#dim_of_coord scrollable#offset in
+    let offset = self#scroll_of_window @@ self#offset in
 
     let c1 = offset in
-    let c2 = offset + scroll_bar_size-1 in
+    let c2 = offset + self#scroll_bar_size - 1 in
     for col=c1 to c2 do
       for row=0 to rows-1 do
         if row=0 || row=rows-1 then
@@ -245,5 +189,4 @@ class hscrollbar
     done
 
 end
-
 

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -148,7 +148,7 @@ class virtual scrollbar =
     method private mouse_scale_ratio scroll = 
       let steps, size = self#scroll_bar_steps, self#scroll_bar_size in
       let wsize = self#scroll_window_size in
-      let dead_zone = wsize / 10 in (* ~10% at each end *)
+      let dead_zone = wsize / 5 in (* ~10% at each end *)
       map_range (wsize - dead_zone - 1) (steps - 1) (scroll - dead_zone/2)
 
     (* place the middle of the scroll bar at the cursor.  Large scroll bars

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -198,10 +198,6 @@ class virtual scrollbar =
 
       | _ -> false
 
-    method debug_offset = scroll_bar_offset
-    method debug_size = self#scroll_bar_size
-    method debug_steps = self#scroll_bar_steps
-
   end
 
 class vscrollbar ?(width=2) () = object(self)
@@ -212,7 +208,9 @@ class vscrollbar ?(width=2) () = object(self)
   method private mouse_offset m alloc = m.LTerm_mouse.row - alloc.row1 
   method private key_scroll_incr = LTerm_key.Down
   method private key_scroll_decr = LTerm_key.Up
-  method private scroll_window_size = self#allocation.row2 - self#allocation.row1
+  method private scroll_window_size =
+    let alloc = self#allocation in
+    alloc.row2 - alloc.row1
 
   method draw ctx focused = 
     let focus = (self :> t) = focused in

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -84,7 +84,7 @@ class type scrollable = object
 
 end
 
-class virtual scrollbar ~scroll_bar_size ~(scrollable:scrollable) =
+class virtual scrollbar ~scroll_bar_size ~(scrollable:#scrollable) =
   let window_of_scroll, scroll_of_window = Proj.make () in
 
   object(self)

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -1,0 +1,249 @@
+open CamomileLibrary
+open LTerm_geom
+
+class t = LTerm_widget_base_impl.t
+
+module Proj = struct
+
+  let create range1 range2 = 
+    assert (range1 >= range2);
+    let range1' = float_of_int range1 in
+    let range2' = float_of_int (range2-1) in
+    Array.init range2 
+      (fun i ->
+        let i' = float_of_int i in
+        max 0 (min range1 
+          (int_of_float @@ ((range1' *. i' /. range2') +. 0.5))))
+  
+  let scale_up t offset = 
+    t.(max 0 (min offset (Array.length t - 1)))
+
+  let scale_down a value = 
+    let (<:) x y = scale_up a x < y in
+    let (>:) x y = scale_up a x > y in
+    let (-:) x y = scale_up a x - y in
+    (* binary search nearest *)
+    let rec search low high =
+      if high = low then low 
+      else if high = low + 1 then
+        if abs (low -: value) < abs (high -: value) then low 
+        else high
+      else 
+        let mid = (low + high) / 2 in
+        if mid >: value then search low mid
+        else if mid <: value then search mid high
+        else mid 
+    in
+    let len = Array.length a in
+    if value < 0 then 0
+    else if (len-1) <: value then len-1
+    else search 0 (len - 1)
+
+  let make () = 
+    let range1', range2' = ref 0, ref 0 in
+    let proj = ref [||] in
+    let memo_create range1 range2 = 
+      if !range1' = range1 && !range2' = range2 then !proj
+      else begin
+        proj := create range1 range2;
+        range1' := range1;
+        range2' := range2;
+        !proj
+      end
+    in
+    let scale_to range1 range2 = 
+      if range1 >= range2 then scale_up (memo_create range1 range2)
+      else scale_down (memo_create range2 range1)
+    in
+    let scale_from range1 range2 = 
+      if range1 >= range2 then scale_down (memo_create range1 range2)
+      else scale_up (memo_create range2 range1)
+    in
+    scale_to, scale_from
+
+end
+
+let hbar = 0x2550
+let vbar = 0x2551
+let lbar = 0x2560
+let rbar = 0x2563
+let tbar = 0x2566
+let bbar = 0x2569
+let xbar = 0x256c
+
+class type scrollable = object
+
+  method full_size : size
+    (* full size of scrollable window *)
+
+  method offset : coord
+    (* offset within window *)
+
+  method set_offset : coord -> unit
+    (* set offset within window *)
+
+end
+
+class virtual scrollbar ~scroll_bar_size ~(scrollable:scrollable) =
+  let window_of_scroll, scroll_of_window = Proj.make () in
+
+  object(self)
+    inherit t "scrollbar"
+
+    method can_focus = true
+
+    method virtual private dim_of_coord : coord -> int
+    method virtual private dim_of_size : size -> int
+    method virtual private dim_of_rect : rect -> int
+    method virtual private mouse_offset : LTerm_mouse.t -> rect -> int
+    method virtual private update_dim : coord -> int -> coord
+    method virtual private key_scroll_incr : LTerm_key.code
+    method virtual private key_scroll_decr : LTerm_key.code
+
+    val mutable focused_style = LTerm_style.none
+    val mutable unfocused_style = LTerm_style.none
+    method update_resources =
+      let rc = self#resource_class and resources = self#resources in
+      focused_style <- LTerm_resources.get_style (rc ^ ".focused") resources;
+      unfocused_style <- LTerm_resources.get_style (rc ^ ".unfocused") resources
+
+    method private window_size = self#dim_of_size scrollable#full_size 
+    method private scroll_steps = self#dim_of_rect self#allocation - scroll_bar_size + 1 
+
+    val mutable scroll_bar_offset = 0
+
+    method private window_of_scroll offset = 
+      scroll_bar_offset <- max 0 (min (self#scroll_steps - 1) offset);
+      window_of_scroll self#window_size self#scroll_steps offset
+
+    method private scroll_of_window offset = 
+      let o = scroll_of_window self#window_size self#scroll_steps offset in
+      scroll_bar_offset <- max 0 (min (self#scroll_steps - 1) o);
+      o
+
+    initializer self#on_event @@ fun ev ->
+      let open LTerm_mouse in
+      let open LTerm_key in
+
+      let alloc = self#allocation in
+      let prev () = self#window_of_scroll (scroll_bar_offset - 1) in
+      let next () = self#window_of_scroll (scroll_bar_offset + 1) in
+      let to_ofs x = self#update_dim scrollable#offset x in
+
+      match ev with
+      | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
+        let scroll = self#mouse_offset m alloc in
+        scrollable#set_offset @@ to_ofs @@ self#window_of_scroll scroll;
+        self#queue_draw;
+        true
+
+      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+        when code=self#key_scroll_decr ->
+        scrollable#set_offset @@ to_ofs (prev ());
+        self#queue_draw;
+        true
+
+      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+        when code=self#key_scroll_incr ->
+        scrollable#set_offset @@ to_ofs (next ());
+        self#queue_draw;
+        true
+
+      | _ -> false
+
+  end
+
+class vscrollbar
+  ?(scroll_bar_size=5) 
+  ?(scroll_window_size=0) 
+  ?(scroll_bar_thickness=2) 
+  ~scrollable = object(self)
+  inherit scrollbar ~scroll_bar_size ~scrollable 
+
+  method size_request = { rows=scroll_window_size; cols=scroll_bar_thickness }
+
+  method private dim_of_coord = row
+  method private dim_of_size = rows
+  method private dim_of_rect r = r.row2 - r.row1
+  method private mouse_offset m alloc = m.LTerm_mouse.row - alloc.row1 
+  method private update_dim c row = { c with LTerm_geom.row }
+  method private key_scroll_incr = LTerm_key.Down
+  method private key_scroll_decr = LTerm_key.Up
+
+  (* ...should try and refactor this into the base class... *)
+  method draw ctx focused = 
+    let focus = (self :> t) = focused in
+    let { cols; _ } = LTerm_draw.size ctx in
+
+    let style = if focus then focused_style else unfocused_style in
+    LTerm_draw.fill_style ctx style;
+
+    let offset = self#scroll_of_window @@ self#dim_of_coord scrollable#offset in
+
+    for col=0 to cols-1 do
+      let r1 = offset in
+      let r2 = offset + scroll_bar_size-1 in
+      for row=r1 to r2 do
+        if col=0 || col=cols-1 then
+          if row=r1 && row=r2 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int xbar
+          else if row=r1 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int tbar
+          else if row=r2 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int bbar
+          else
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int vbar
+        else if row=r1 || row=r2 then
+          LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int hbar
+      done
+    done
+
+end
+
+class hscrollbar
+  ?(scroll_bar_size=5) 
+  ?(scroll_window_size=0) 
+  ?(scroll_bar_thickness=2) 
+  ~scrollable = object(self)
+  inherit scrollbar ~scroll_bar_size ~scrollable 
+
+  method size_request = { cols=scroll_window_size; rows=scroll_bar_thickness }
+
+  method private dim_of_coord = col
+  method private dim_of_size = cols
+  method private dim_of_rect r = r.col2 - r.col1
+  method private mouse_offset m alloc = m.LTerm_mouse.col - alloc.col1 
+  method private update_dim c col = { c with LTerm_geom.col }
+  method private key_scroll_incr = LTerm_key.Right
+  method private key_scroll_decr = LTerm_key.Left
+
+  method draw ctx focused = 
+    let focus = (self :> t) = focused in
+    let { rows; _ } = LTerm_draw.size ctx in
+
+    let style = if focus then focused_style else unfocused_style in
+    LTerm_draw.fill_style ctx style;
+
+    let offset = self#scroll_of_window @@ self#dim_of_coord scrollable#offset in
+
+    let c1 = offset in
+    let c2 = offset + scroll_bar_size-1 in
+    for col=c1 to c2 do
+      for row=0 to rows-1 do
+        if row=0 || row=rows-1 then
+          if col=c1 && col=c2 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int xbar
+          else if col=c1 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int lbar
+          else if col=c2 then
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int rbar
+          else
+            LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int hbar
+        else if col=c1 || col=c2 then
+          LTerm_draw.draw_char ~style ctx row col @@ UChar.of_int vbar
+      done
+    done
+
+end
+
+

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -6,40 +6,6 @@ class t = LTerm_widget_base_impl.t
 let hbar = 0x2550
 let vbar = 0x2551
 
-class type adjustment = object
-  method range : int
-  method set_range : int -> unit
-
-  method offset : int
-  method set_offset : int -> unit
-  method on_offset_change : ?switch:LTerm_widget_callbacks.switch -> 
-    (int -> unit) -> unit
-end
-
-class type scrollable_adjustment = object
-  inherit adjustment
-
-  (* public interface *)
-
-  method incr : unit
-  method decr : unit
-
-  method mouse_scroll : int -> unit
-  
-  method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
-  method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
-  method set_min_scroll_bar_size : int -> unit
-  method set_max_scroll_bar_size : int -> unit
-
-  method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch -> 
-    (unit -> unit) -> unit
-
-  (* private scrollbar interface *)
-
-  method set_scroll_window_size : int -> unit
-  method get_render_params : int * int * int
-end
-
 let map_range range1 range2 offset1 = 
   if range1 = 0 then 0 
   else
@@ -52,32 +18,46 @@ let map_range range1 range2 offset1 =
       (float_of_int range2)
       (float_of_int offset1)
 
-class default_scrollable_adjustment = object(self)
+class adjustment = object(self)
 
   (* callbacks *)
   val offset_change_callbacks = Lwt_sequence.create ()
   method on_offset_change ?switch (f : int -> unit) = 
     LTerm_widget_callbacks.register switch offset_change_callbacks f
 
-  val scrollbar_change_callbacks = Lwt_sequence.create ()
-  method on_scrollbar_change ?switch (f : unit -> unit) = 
-    LTerm_widget_callbacks.register switch scrollbar_change_callbacks f
-
   val mutable range = 0
   val mutable offset = 0
 
   method range = range
-  method set_range r = 
+  method set_range ?(trigger_callback=true) r = 
     range <- max 0 r;
-    self#set_offset offset (* ensure offset is clipped to the new range *)
+    self#set_offset ~trigger_callback offset (* ensure offset is clipped to the new range *)
 
   method offset = offset
-  method set_offset o = 
+  method set_offset ?(trigger_callback=true) o = 
     let o' = max 0 (min (range-1) o) in
     if offset <> o' then begin
-      offset <- o';  
-      LTerm_widget_callbacks.exec_callbacks offset_change_callbacks o'
+      offset <- o'; 
+      if trigger_callback then
+        LTerm_widget_callbacks.exec_callbacks offset_change_callbacks o'
     end
+
+end
+
+class scrollable_adjustment = object(self)
+  inherit adjustment as adj
+
+  val scrollbar_change_callbacks = Lwt_sequence.create ()
+  method on_scrollbar_change ?switch (f : unit -> unit) = 
+    LTerm_widget_callbacks.register switch scrollbar_change_callbacks f
+
+  method set_offset ?(trigger_callback=true) o = 
+    adj#set_offset ~trigger_callback o;
+    self#set_scroll_bar_offset (self#scroll_of_window self#offset)
+
+  method set_range ?(trigger_callback=true) r = 
+    adj#set_range ~trigger_callback r;
+    self#set_scroll_bar_offset (self#scroll_of_window self#offset)
 
   val mutable scroll_window_size = 0
   method private scroll_window_size = scroll_window_size
@@ -139,25 +119,23 @@ class default_scrollable_adjustment = object(self)
     end)
 
   method private window_of_scroll offset = 
-    self#set_scroll_bar_offset offset;
-    map_range (self#scroll_bar_steps-1) (range-1) scroll_bar_offset
+    map_range (self#scroll_bar_steps-1) (range-1) offset
 
   method private scroll_of_window offset = 
     let offset = map_range (range-1) (self#scroll_bar_steps-1) offset in
-    self#set_scroll_bar_offset offset;
-    scroll_bar_offset
+    offset
 
   method incr = 
     if range >= self#scroll_bar_steps then
-      self#set_offset @@ self#window_of_scroll (scroll_bar_offset+1) 
+      self#window_of_scroll (scroll_bar_offset+1) 
     else
-      self#set_offset (offset+1);
+      (offset+1);
 
   method decr = 
     if range >= self#scroll_bar_steps then
-      self#set_offset @@ self#window_of_scroll (scroll_bar_offset-1) 
+      self#window_of_scroll (scroll_bar_offset-1) 
     else
-      self#set_offset (offset-1);
+      (offset-1);
 
   (* mouse click control *)
 
@@ -192,10 +170,34 @@ class default_scrollable_adjustment = object(self)
     | `auto -> self#mouse_scale_auto scroll
 
   method mouse_scroll scroll =
-    self#set_offset @@ self#window_of_scroll @@ self#scroll_of_mouse scroll
+    self#window_of_scroll @@ self#scroll_of_mouse scroll
+
+  val mutable page_size = -1 
+  val mutable document_size = -1
+
+  method calculate_range page_size document_size = document_size-page_size+1
+
+  method private update_page_and_document_sizes page doc = 
+    if page_size <> page || document_size <> doc then begin
+      page_size <- page;
+      document_size <- doc;
+      let range = max 0 (self#calculate_range page_size document_size) in
+      self#set_range range;
+      self#set_mouse_mode `auto;
+      self#set_scroll_bar_mode (`dynamic page_size);
+    end
+
+  method page_size = page_size
+  method set_page_size s = self#update_page_and_document_sizes s document_size
+
+  method document_size = document_size
+  method set_document_size s = self#update_page_and_document_sizes page_size s
+
+  method page_prev = self#offset - page_size
+  method page_next = self#offset + page_size
 
   method get_render_params = 
-    self#scroll_of_window @@ self#offset,
+    scroll_bar_offset,
     self#scroll_bar_size, 
     self#scroll_window_size
 
@@ -242,17 +244,17 @@ class virtual scrollbar rc (adj : #scrollable_adjustment) = object(self)
     match ev with
     | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
       let scroll = self#mouse_offset m alloc in
-      adj#mouse_scroll scroll;
+      adj#set_offset @@ adj#mouse_scroll scroll;
       true
 
     | LTerm_event.Key { control = false; meta = false; shift = true; code } 
       when code=self#key_scroll_decr ->
-      adj#decr;
+      adj#set_offset adj#decr;
       true
 
     | LTerm_event.Key { control = false; meta = false; shift = true; code } 
       when code=self#key_scroll_incr ->
-      adj#incr;
+      adj#set_offset adj#incr;
       true
 
     | _ -> false
@@ -282,7 +284,7 @@ class virtual scrollbar rc (adj : #scrollable_adjustment) = object(self)
 
 end
 
-class vscrollbar_for_adjustment  ?(rc="scrollbar") ?(width=2) adj = object(self)
+class vscrollbar ?(rc="scrollbar") ?(width=2) adj = object(self)
   inherit scrollbar rc adj as super
 
   method size_request = { rows=0; cols=width }
@@ -315,7 +317,7 @@ class vscrollbar_for_adjustment  ?(rc="scrollbar") ?(width=2) adj = object(self)
 
 end
 
-class hscrollbar_for_adjustment  ?(rc="scrollbar") ?(height=2) adj = object(self)
+class hscrollbar ?(rc="scrollbar") ?(height=2) adj = object(self)
   inherit scrollbar rc adj as super
   
   method size_request = { rows=height; cols=0 }
@@ -328,7 +330,6 @@ class hscrollbar_for_adjustment  ?(rc="scrollbar") ?(height=2) adj = object(self
     super#set_allocation r;
     adj#set_scroll_window_size (r.col2 - r.col1)
 
-
   method draw ctx focused = 
     let open LTerm_draw in
     let focus = (self :> t) = focused in
@@ -337,7 +338,6 @@ class hscrollbar_for_adjustment  ?(rc="scrollbar") ?(height=2) adj = object(self
     let style = if focus then focused_style else unfocused_style in
     fill_style ctx style;
 
-    (*let offset = adj#scroll_of_window @@ adj#offset in*)
     let offset, scroll_bar_size, scroll_window_size = adj#get_render_params in
 
     let rect = 
@@ -350,47 +350,35 @@ class hscrollbar_for_adjustment  ?(rc="scrollbar") ?(height=2) adj = object(self
 
 end
 
-class vscrollbar ?(rc="scrollbar") ?(width=2) () = 
-  let adj = new default_scrollable_adjustment in
+class vslider rng = 
+  let adj = new scrollable_adjustment in
   object(self)
-    inherit vscrollbar_for_adjustment ~rc ~width adj 
-
-    method range  = adj#range
-    method set_range = adj#set_range
+    inherit vscrollbar ~rc:"slider" ~width:1 adj
+    initializer
+      adj#set_mouse_mode `middle;
+      adj#set_scroll_bar_mode (`fixed 1);
+      adj#set_range (max 0 rng)
+    method size_request = { rows=rng; cols=1 }
     method offset = adj#offset
     method set_offset = adj#set_offset
+    method range = adj#range
+    method set_range = adj#set_range
     method on_offset_change = adj#on_offset_change
-    method incr = adj#incr
-    method decr = adj#decr
-    method mouse_scroll = adj#mouse_scroll
-    method set_scroll_bar_mode = adj#set_scroll_bar_mode
-    method set_mouse_mode = adj#set_mouse_mode
-    method set_min_scroll_bar_size = adj#set_min_scroll_bar_size
-    method set_max_scroll_bar_size = adj#set_max_scroll_bar_size
-    method on_scrollbar_change = adj#on_scrollbar_change
-    method set_scroll_window_size = adj#set_scroll_window_size
-    method get_render_params = adj#get_render_params
   end
 
-class hscrollbar ?(rc="scrollbar") ?(height=2) () = 
-  let adj = new default_scrollable_adjustment in
+class hslider rng = 
+  let adj = new scrollable_adjustment in
   object(self)
-    inherit hscrollbar_for_adjustment ~rc ~height adj 
-
-    method range  = adj#range
-    method set_range = adj#set_range
+    inherit hscrollbar ~rc:"slider" ~height:1 adj
+    initializer
+      adj#set_mouse_mode `middle;
+      adj#set_scroll_bar_mode (`fixed 1);
+      adj#set_range (max 0 rng)
+    method size_request = { rows=1; cols=rng }
     method offset = adj#offset
     method set_offset = adj#set_offset
+    method range = adj#range
+    method set_range = adj#set_range
     method on_offset_change = adj#on_offset_change
-    method incr = adj#incr
-    method decr = adj#decr
-    method mouse_scroll = adj#mouse_scroll
-    method set_scroll_bar_mode = adj#set_scroll_bar_mode
-    method set_mouse_mode = adj#set_mouse_mode
-    method set_min_scroll_bar_size = adj#set_min_scroll_bar_size
-    method set_max_scroll_bar_size = adj#set_max_scroll_bar_size
-    method on_scrollbar_change = adj#on_scrollbar_change
-    method set_scroll_window_size = adj#set_scroll_window_size
-    method get_render_params = adj#get_render_params
   end
 

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -80,7 +80,9 @@ class virtual scrollbar =
       else max 1 size
 
     method private scroll_bar_size_dynamic view_size = 
-      if view_size <= 0 then
+      if range <= 1 then
+        self#scroll_window_size
+      else if view_size <= 0 then
         max 1 (self#scroll_window_size / max 1 range)
       else
         let range = float_of_int range in

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -121,9 +121,10 @@ class default_scrollable_adjustment = object(self)
       | `fixed size -> self#scroll_bar_size_fixed size
       | `dynamic size -> self#scroll_bar_size_dynamic size
     in
-    (if scroll_bar_size <> size then 
+    (if scroll_bar_size <> size then begin
       scroll_bar_size <- size;
-      LTerm_widget_callbacks.exec_callbacks scrollbar_change_callbacks ());
+      LTerm_widget_callbacks.exec_callbacks scrollbar_change_callbacks ()
+    end);
     size
 
   method private scroll_bar_steps = 
@@ -132,9 +133,10 @@ class default_scrollable_adjustment = object(self)
   val mutable scroll_bar_offset = 0
   method private set_scroll_bar_offset o = 
     let offset = max 0 (min (self#scroll_bar_steps-1) o) in
-    (if scroll_bar_offset <> offset then 
+    (if scroll_bar_offset <> offset then begin
       scroll_bar_offset <- offset;
-      LTerm_widget_callbacks.exec_callbacks scrollbar_change_callbacks ())
+      LTerm_widget_callbacks.exec_callbacks scrollbar_change_callbacks ()
+    end)
 
   method private window_of_scroll offset = 
     self#set_scroll_bar_offset offset;

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -9,237 +9,263 @@ let vbar = 0x2551
 class type adjustment = object
   method range : int
   method set_range : int -> unit
+
   method offset : int
   method set_offset : int -> unit
   method on_offset_change : ?switch:LTerm_widget_callbacks.switch -> 
     (int -> unit) -> unit
-  method incr : unit
-  method decr : unit
 end
 
-class virtual scrollbar rc = 
-  let map_range range1 range2 offset1 = 
-    if range1 = 0 then 0 
+class type scrollable_adjustment = object
+  inherit adjustment
+
+  (* public interface *)
+
+  method incr : unit
+  method decr : unit
+
+  method set_scroll_bar_mode : [ `fixed of int | `dynamic of int ] -> unit
+  method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
+  method set_min_scroll_bar_size : int -> unit
+  method set_max_scroll_bar_size : int -> unit
+
+  (* private scrollbar interface *)
+
+  method set_scroll_window_size : int -> unit
+  method set_scroll_bar_offset : int -> unit
+  method scroll_window_size : int
+  method scroll_bar_size : int
+  method scroll_bar_steps : int
+  method scroll_of_window : int -> int
+  method window_of_scroll : int -> int
+  method scroll_of_mouse : int -> int
+end
+
+let map_range range1 range2 offset1 = 
+  if range1 = 0 then 0 
+  else
+    let map_range range1 range2 offset1 = 
+      max 0. (min range2 (range2 *. offset1 /. range1)) 
+    in
+    let rnd x = int_of_float (x +. 0.5) in
+    rnd @@ map_range 
+      (float_of_int range1)
+      (float_of_int range2)
+      (float_of_int offset1)
+
+class default_scrollable_adjustment = object(self)
+
+  val offset_change_callbacks = Lwt_sequence.create ()
+  method on_offset_change ?switch (f : int -> unit) = 
+    LTerm_widget_callbacks.register switch offset_change_callbacks f
+
+  val mutable range = 0
+  val mutable offset = 0
+
+  method range = range
+  method set_range r = 
+    range <- max 0 r;
+    self#set_offset offset (* ensure offset is clipped to the new range *)
+
+  method offset = offset
+  method set_offset o = 
+    let o' = max 0 (min (range-1) o) in
+    if offset <> o' then begin
+      offset <- o';  
+      LTerm_widget_callbacks.exec_callbacks offset_change_callbacks o'
+    end
+
+  val mutable scroll_window_size = 0
+  method scroll_window_size = scroll_window_size
+  method set_scroll_window_size s = scroll_window_size <- s
+
+  val mutable scroll_bar_mode : [ `fixed of int | `dynamic of int ] = `fixed 5
+  method set_scroll_bar_mode m = scroll_bar_mode <- m
+  
+  method private scroll_bar_size_fixed size = 
+    let wsize = self#scroll_window_size in
+    if wsize <= size then max 1 (wsize-1)
+    else max 1 size
+
+  method private scroll_bar_size_dynamic view_size = 
+    if range <= 1 then
+      self#scroll_window_size
+    else if view_size <= 0 then
+      max 1 (self#scroll_window_size / max 1 range)
     else
-      let map_range range1 range2 offset1 = 
-        max 0. (min range2 (range2 *. offset1 /. range1)) 
+      let range = float_of_int range in
+      let scroll_size = float_of_int @@ self#scroll_window_size in
+      let view_size = float_of_int view_size in
+      let doc_size = view_size +. range in
+      int_of_float @@ scroll_size *. view_size /. doc_size
+
+  val mutable min_scroll_bar_size : int option = None
+  method private min_scroll_bar_size = 
+    match min_scroll_bar_size with None -> 1 | Some(x) -> x
+  method set_min_scroll_bar_size min = min_scroll_bar_size <- Some(min)
+    
+  val mutable max_scroll_bar_size : int option = None
+  method private max_scroll_bar_size = 
+    match max_scroll_bar_size with None -> self#scroll_window_size | Some(x) -> x
+  method set_max_scroll_bar_size max = max_scroll_bar_size <- Some(max)
+
+  method scroll_bar_size = 
+    max self#min_scroll_bar_size @@ min self#max_scroll_bar_size @@
+    match scroll_bar_mode with
+    | `fixed size -> self#scroll_bar_size_fixed size
+    | `dynamic size -> self#scroll_bar_size_dynamic size
+
+  method scroll_bar_steps = 
+    self#scroll_window_size - self#scroll_bar_size + 1
+
+  val mutable scroll_bar_offset = 0
+  method set_scroll_bar_offset o = 
+    scroll_bar_offset <- max 0 (min (self#scroll_bar_steps-1) o)
+
+  method window_of_scroll offset = 
+    self#set_scroll_bar_offset offset;
+    map_range (self#scroll_bar_steps-1) (range-1) scroll_bar_offset
+
+  method scroll_of_window offset = 
+    let offset = map_range (range-1) (self#scroll_bar_steps-1) offset in
+    self#set_scroll_bar_offset offset;
+    scroll_bar_offset
+
+  method incr = 
+    if range >= self#scroll_bar_steps then
+      self#set_offset @@ self#window_of_scroll (scroll_bar_offset+1) 
+    else
+      self#set_offset (offset+1);
+
+  method decr = 
+    if range >= self#scroll_bar_steps then
+      self#set_offset @@ self#window_of_scroll (scroll_bar_offset-1) 
+    else
+      self#set_offset (offset-1);
+
+  (* mouse click control *)
+
+  (* scale whole scroll bar area into the number of steps.  The scroll
+      bar will not necessarily end up where clicked.  Add a small dead_zone
+      at far left and right *)
+  method private mouse_scale_ratio scroll = 
+    let steps, size = self#scroll_bar_steps, self#scroll_bar_size in
+    let wsize = self#scroll_window_size in
+    let dead_zone = wsize / 5 in (* ~10% at each end *)
+    map_range (wsize - dead_zone - 1) (steps - 1) (scroll - dead_zone/2)
+
+  (* place the middle of the scroll bar at the cursor.  Large scroll bars
+      will reduce the clickable area by their size. *)
+  method private mouse_scale_middle scroll = 
+    let size = self#scroll_bar_size in
+    scroll - (size/2)
+
+  method private mouse_scale_auto scroll = 
+    if self#scroll_bar_size > self#scroll_window_size/2 then 
+      self#mouse_scale_ratio scroll
+    else 
+      self#mouse_scale_middle scroll
+
+  val mutable mouse_mode : [ `middle | `ratio | `auto ] = `middle
+  method set_mouse_mode m = mouse_mode <- m
+
+  method scroll_of_mouse scroll = 
+    match mouse_mode with
+    | `middle -> self#mouse_scale_middle scroll
+    | `ratio -> self#mouse_scale_ratio scroll
+    | `auto -> self#mouse_scale_auto scroll
+
+end
+
+class virtual scrollbar rc (adj : #scrollable_adjustment) = object(self)
+  inherit t rc
+
+  method can_focus = true
+
+  (* style *)
+  val mutable focused_style = LTerm_style.none
+  val mutable unfocused_style = LTerm_style.none
+  val mutable bar_style : [ `filled | `outline ] = `outline
+  val mutable show_track = false
+  method update_resources =
+    let rc = self#resource_class and resources = self#resources in
+    focused_style <- LTerm_resources.get_style (rc ^ ".focused") resources;
+    unfocused_style <- LTerm_resources.get_style (rc ^ ".unfocused") resources;
+    bar_style <- 
+      (match LTerm_resources.get (rc ^ ".barstyle") resources with
+      | "filled" -> `filled
+      | "outline" | "" -> `outline
+      | str -> Printf.ksprintf failwith "invalid scrollbar style");
+    show_track <- 
+      (match LTerm_resources.get_bool (rc ^ ".track") resources with
+      | Some(x) -> x
+      | None -> false)
+
+  (* virtual methods needed to abstract over vert/horz scrollbars *)
+
+  method virtual private mouse_offset : LTerm_mouse.t -> rect -> int
+  method virtual private key_scroll_incr : LTerm_key.code
+  method virtual private key_scroll_decr : LTerm_key.code
+
+  (* event handling *)
+
+  initializer self#on_event @@ fun ev ->
+    let open LTerm_mouse in
+    let open LTerm_key in
+
+    let alloc = self#allocation in
+
+    match ev with
+    | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
+      let scroll = self#mouse_offset m alloc in
+      adj#set_offset @@ adj#window_of_scroll @@ adj#scroll_of_mouse scroll;
+      true
+
+    | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+      when code=self#key_scroll_decr ->
+      adj#decr;
+      true
+
+    | LTerm_event.Key { control = false; meta = false; shift = true; code } 
+      when code=self#key_scroll_incr ->
+      adj#incr;
+      true
+
+    | _ -> false
+
+  (* drawing *)
+  method private draw_bar ctx style rect =
+    let open LTerm_draw in
+    let { cols; rows } = size_of_rect rect in
+    if cols=1 || rows=1 || bar_style=`filled then
+      let x = 
+        CamomileLibrary.UChar.of_int @@
+          if bar_style=`filled then 0x2588
+          else if cols=1 then vbar
+          else hbar
       in
-      let rnd x = int_of_float (x +. 0.5) in
-      rnd @@ map_range 
-        (float_of_int range1)
-        (float_of_int range2)
-        (float_of_int offset1)
-  in
-  object(self)
-    inherit t rc
-
-    method can_focus = true
-
-    (* style *)
-    val mutable focused_style = LTerm_style.none
-    val mutable unfocused_style = LTerm_style.none
-    val mutable bar_style : [ `filled | `outline ] = `outline
-    val mutable show_track = false
-    method update_resources =
-      let rc = self#resource_class and resources = self#resources in
-      focused_style <- LTerm_resources.get_style (rc ^ ".focused") resources;
-      unfocused_style <- LTerm_resources.get_style (rc ^ ".unfocused") resources;
-      bar_style <- 
-        (match LTerm_resources.get (rc ^ ".barstyle") resources with
-        | "filled" -> `filled
-        | "outline" | "" -> `outline
-        | str -> Printf.ksprintf failwith "invalid scrollbar style");
-      show_track <- 
-        (match LTerm_resources.get_bool (rc ^ ".track") resources with
-        | Some(x) -> x
-        | None -> false)
-
-    (* callback *)
-    val offset_change_callbacks = Lwt_sequence.create ()
-    method on_offset_change ?switch (f : int -> unit) = 
-      LTerm_widget_callbacks.register switch offset_change_callbacks f
-
-    (* adjustable *)
-    val mutable range = 0
-    val mutable offset = 0
-    method range = range
-    method set_range r = 
-      range <- max 0 r;
-      self#set_offset offset (* ensure offset is clipped to the new range *)
-    method offset = offset
-    method set_offset o = 
-      let o' = max 0 (min (range-1) o) in
-      if offset <> o' then begin
-        offset <- o';  
-        LTerm_widget_callbacks.exec_callbacks offset_change_callbacks o'
-      end;
-      self#queue_draw
-    
-    (* configuration of the scroll bar *)
-
-    val mutable scroll_bar_mode : [ `fixed of int | `dynamic of int ] = `fixed 5
-    method set_scroll_bar_mode m = scroll_bar_mode <- m
-    
-    method private scroll_bar_size_fixed size = 
-      let wsize = self#scroll_window_size in
-      if wsize <= size then max 1 (wsize-1)
-      else max 1 size
-
-    method private scroll_bar_size_dynamic view_size = 
-      if range <= 1 then
-        self#scroll_window_size
-      else if view_size <= 0 then
-        max 1 (self#scroll_window_size / max 1 range)
-      else
-        let range = float_of_int range in
-        let scroll_size = float_of_int @@ self#scroll_window_size in
-        let view_size = float_of_int view_size in
-        let doc_size = view_size +. range in
-        int_of_float @@ scroll_size *. view_size /. doc_size
-
-    val mutable min_scroll_bar_size : int option = None
-    method private min_scroll_bar_size = 
-      match min_scroll_bar_size with None -> 1 | Some(x) -> x
-    method set_min_scroll_bar_size min = min_scroll_bar_size <- Some(min)
-     
-    val mutable max_scroll_bar_size : int option = None
-    method private max_scroll_bar_size = 
-      match max_scroll_bar_size with None -> self#scroll_window_size | Some(x) -> x
-    method set_max_scroll_bar_size max = max_scroll_bar_size <- Some(max)
-
-    method scroll_bar_size = 
-      max self#min_scroll_bar_size @@ min self#max_scroll_bar_size @@
-      match scroll_bar_mode with
-      | `fixed size -> self#scroll_bar_size_fixed size
-      | `dynamic size -> self#scroll_bar_size_dynamic size
-
-    (* virtual methods needed to abstract over vert/horz scrollbars *)
-
-    method virtual private mouse_offset : LTerm_mouse.t -> rect -> int
-    method virtual private key_scroll_incr : LTerm_key.code
-    method virtual private key_scroll_decr : LTerm_key.code
-    method virtual private scroll_window_size : int
-
-    (* coordinate system conversions *)
-
-    method private scroll_bar_steps = 
-      self#scroll_window_size - self#scroll_bar_size + 1
-
-    val mutable scroll_bar_offset = 0
-    method private set_scroll_bar_offset o = 
-      scroll_bar_offset <- max 0 (min (self#scroll_bar_steps-1) o)
-
-    method private window_of_scroll offset = 
-      self#set_scroll_bar_offset offset;
-      map_range (self#scroll_bar_steps-1) (range-1) scroll_bar_offset
-
-    method private scroll_of_window offset = 
-      let offset = map_range (range-1) (self#scroll_bar_steps-1) offset in
-      self#set_scroll_bar_offset offset;
-      scroll_bar_offset
-
-    method incr = 
-      if range >= self#scroll_bar_steps then
-        self#set_offset @@ self#window_of_scroll (scroll_bar_offset+1) 
-      else
-        self#set_offset (self#offset+1);
-
-    method decr = 
-      if range >= self#scroll_bar_steps then
-        self#set_offset @@ self#window_of_scroll (scroll_bar_offset-1) 
-      else
-        self#set_offset (self#offset-1);
-
-    (* mouse click control *)
-
-    (* scale whole scroll bar area into the number of steps.  The scroll
-       bar will not necessarily end up where clicked.  Add a small dead_zone
-       at far left and right *)
-    method private mouse_scale_ratio scroll = 
-      let steps, size = self#scroll_bar_steps, self#scroll_bar_size in
-      let wsize = self#scroll_window_size in
-      let dead_zone = wsize / 5 in (* ~10% at each end *)
-      map_range (wsize - dead_zone - 1) (steps - 1) (scroll - dead_zone/2)
-
-    (* place the middle of the scroll bar at the cursor.  Large scroll bars
-       will reduce the clickable area by their size. *)
-    method private mouse_scale_middle scroll = 
-      let size = self#scroll_bar_size in
-      scroll - (size/2)
-
-    method private mouse_scale_auto scroll = 
-      if self#scroll_bar_size > self#scroll_window_size/2 then 
-        self#mouse_scale_ratio scroll
-      else 
-        self#mouse_scale_middle scroll
-
-    val mutable mouse_mode : [ `middle | `ratio | `auto ] = `middle
-    method set_mouse_mode m = mouse_mode <- m
-
-    method scroll_of_mouse scroll = 
-      match mouse_mode with
-      | `middle -> self#mouse_scale_middle scroll
-      | `ratio -> self#mouse_scale_ratio scroll
-      | `auto -> self#mouse_scale_auto scroll
-
-    (* event handling *)
-
-    initializer self#on_event @@ fun ev ->
-      let open LTerm_mouse in
-      let open LTerm_key in
-
-      let alloc = self#allocation in
-
-      match ev with
-      | LTerm_event.Mouse m when m.button=Button1 && in_rect alloc (coord m) ->
-        let scroll = self#mouse_offset m alloc in
-        self#set_offset @@ self#window_of_scroll @@ self#scroll_of_mouse scroll;
-        true
-
-      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
-        when code=self#key_scroll_decr ->
-        self#decr;
-        true
-
-      | LTerm_event.Key { control = false; meta = false; shift = true; code } 
-        when code=self#key_scroll_incr ->
-        self#incr;
-        true
-
-      | _ -> false
-
-    (* drawing *)
-    method private draw_bar ctx style rect =
-      let open LTerm_draw in
-      let { cols; rows } = size_of_rect rect in
-      if cols=1 || rows=1 || bar_style=`filled then
-        let x = 
-          CamomileLibrary.UChar.of_int @@
-            if bar_style=`filled then 0x2588
-            else if cols=1 then vbar
-            else hbar
-        in
-        for c=rect.col1 to rect.col2-1 do
-          for r=rect.row1 to rect.row2-1 do
-            draw_char ctx r c ~style x
-          done
+      for c=rect.col1 to rect.col2-1 do
+        for r=rect.row1 to rect.row2-1 do
+          draw_char ctx r c ~style x
         done
-      else
-        draw_frame ctx rect ~style Light
+      done
+    else
+      draw_frame ctx rect ~style Light
 
-  end
+end
 
-class vscrollbar ?(rc="scrollbar") ?(width=2) () = object(self)
-  inherit scrollbar rc
+class vscrollbar_for_adjustment  ?(rc="scrollbar") ?(width=2) adj = object(self)
+  inherit scrollbar rc adj as super
 
   method size_request = { rows=0; cols=width }
 
   method private mouse_offset m alloc = m.LTerm_mouse.row - alloc.row1 
   method private key_scroll_incr = LTerm_key.Down
   method private key_scroll_decr = LTerm_key.Up
-  method private scroll_window_size =
-    let alloc = self#allocation in
-    alloc.row2 - alloc.row1
+
+  method set_allocation r = 
+    super#set_allocation r;
+    adj#set_scroll_window_size (r.row2 - r.row1)
 
   method draw ctx focused = 
     let open LTerm_draw in
@@ -249,29 +275,31 @@ class vscrollbar ?(rc="scrollbar") ?(width=2) () = object(self)
     let style = if focus then focused_style else unfocused_style in
     fill_style ctx style;
 
-    let offset = self#scroll_of_window @@ self#offset in
+    let offset = adj#scroll_of_window @@ adj#offset in
 
     let rect =  
       { row1 = offset; col1 = 0;
-        row2 = offset + self#scroll_bar_size; col2 = cols }
+        row2 = offset + adj#scroll_bar_size; col2 = cols }
     in
 
-    (if show_track then draw_vline ctx 0 (cols/2) self#scroll_bar_size ~style Light);
+    (if show_track then draw_vline ctx 0 (cols/2) adj#scroll_window_size ~style Light);
     self#draw_bar ctx style rect
 
 end
 
-class hscrollbar ?(rc="scrollbar") ?(height=2) () = object(self)
-  inherit scrollbar rc
+class hscrollbar_for_adjustment  ?(rc="scrollbar") ?(height=2) adj = object(self)
+  inherit scrollbar rc adj as super
   
   method size_request = { rows=height; cols=0 }
 
   method private mouse_offset m alloc = m.LTerm_mouse.col - alloc.col1 
   method private key_scroll_incr = LTerm_key.Right
   method private key_scroll_decr = LTerm_key.Left
-  method private scroll_window_size = 
-    let alloc = self#allocation in
-    alloc.col2 - alloc.col1
+
+  method set_allocation r = 
+    super#set_allocation r;
+    adj#set_scroll_window_size (r.col2 - r.col1)
+
 
   method draw ctx focused = 
     let open LTerm_draw in
@@ -281,15 +309,67 @@ class hscrollbar ?(rc="scrollbar") ?(height=2) () = object(self)
     let style = if focus then focused_style else unfocused_style in
     fill_style ctx style;
 
-    let offset = self#scroll_of_window @@ self#offset in
+    let offset = adj#scroll_of_window @@ adj#offset in
 
     let rect = 
       { row1 = 0; col1 = offset;
-        row2 = rows; col2 = offset + self#scroll_bar_size }
+        row2 = rows; col2 = offset + adj#scroll_bar_size }
     in
 
-    (if show_track then draw_hline ctx (rows/2) 0 self#scroll_window_size ~style Light);
+    (if show_track then draw_hline ctx (rows/2) 0 adj#scroll_window_size ~style Light);
     self#draw_bar ctx style rect
 
 end
+
+class vscrollbar ?(rc="scrollbar") ?(width=2) () = 
+  let adj = new default_scrollable_adjustment in
+  object(self)
+    inherit vscrollbar_for_adjustment ~rc ~width adj 
+
+    method range  = adj#range
+    method set_range = adj#set_range
+    method offset = adj#offset
+    method set_offset = adj#set_offset
+    method on_offset_change = adj#on_offset_change
+    method incr = adj#incr
+    method decr = adj#decr
+    method set_scroll_bar_mode = adj#set_scroll_bar_mode
+    method set_mouse_mode = adj#set_mouse_mode
+    method set_min_scroll_bar_size = adj#set_min_scroll_bar_size
+    method set_max_scroll_bar_size = adj#set_max_scroll_bar_size
+    method set_scroll_window_size = adj#set_scroll_window_size
+    method set_scroll_bar_offset = adj#set_scroll_bar_offset
+    method scroll_window_size = adj#scroll_window_size
+    method scroll_bar_size = adj#scroll_bar_size
+    method scroll_bar_steps = adj#scroll_bar_steps
+    method scroll_of_window = adj#scroll_of_window
+    method window_of_scroll = adj#window_of_scroll
+    method scroll_of_mouse = adj#scroll_of_mouse
+  end
+
+class hscrollbar ?(rc="scrollbar") ?(height=2) () = 
+  let adj = new default_scrollable_adjustment in
+  object(self)
+    inherit hscrollbar_for_adjustment ~rc ~height adj 
+
+    method range  = adj#range
+    method set_range = adj#set_range
+    method offset = adj#offset
+    method set_offset = adj#set_offset
+    method on_offset_change = adj#on_offset_change
+    method incr = adj#incr
+    method decr = adj#decr
+    method set_scroll_bar_mode = adj#set_scroll_bar_mode
+    method set_mouse_mode = adj#set_mouse_mode
+    method set_min_scroll_bar_size = adj#set_min_scroll_bar_size
+    method set_max_scroll_bar_size = adj#set_max_scroll_bar_size
+    method set_scroll_window_size = adj#set_scroll_window_size
+    method set_scroll_bar_offset = adj#set_scroll_bar_offset
+    method scroll_window_size = adj#scroll_window_size
+    method scroll_bar_size = adj#scroll_bar_size
+    method scroll_bar_steps = adj#scroll_bar_steps
+    method scroll_of_window = adj#scroll_of_window
+    method window_of_scroll = adj#window_of_scroll
+    method scroll_of_mouse = adj#scroll_of_mouse
+  end
 

--- a/src/widget_impl/lTerm_scroll_impl.ml
+++ b/src/widget_impl/lTerm_scroll_impl.ml
@@ -57,7 +57,9 @@ class virtual scrollbar =
     val mutable range = 0
     val mutable offset = 0
     method range = range
-    method set_range r = range <- max 0 r
+    method set_range r = 
+      range <- max 0 r;
+      self#set_offset offset (* ensure offset is clipped to the new range *)
     method offset = offset
     method set_offset o = 
       let o' = max 0 (min (range-1) o) in


### PR DESCRIPTION
Introduces `hscrollbar` and `vscrollbar` widgets.  Scrollable widgets should implement the `scrollable` interface (although there are none at the moment).

Scrolling can be performed with the mouse, keyboard (shift+[up|down|left|right]) or externally (ie via buttons - such an event should cause a redraw).  A simple example is provided in `scroll.ml`.  A second example is provided in `asciiart` but that is off by default as it requires camlimages (turn on with `./configure --enable-images`).

I've also added a `spacing` widget which is similar to `new t "glue"` but allows a default size to be specified.  See the `with_scrollbar` function for an example of its use.