### PR TITLE
Allow specifying the size of an LTerm_edit.edit widget

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -90,6 +90,14 @@ Library "lambda-term"
 # | Examples                                                          |
 # +-------------------------------------------------------------------+
 
+Executable double_editor
+  Path: examples
+  Install: false
+  CompiledObject: best
+  MainIs: double_editor.ml
+  BuildDepends: lambda-term
+  Build$: flag(examples)
+
 Executable events
   Path: examples
   Install: false

--- a/examples/double_editor.ml
+++ b/examples/double_editor.ml
@@ -6,6 +6,7 @@
  *
  * This file is a part of Lambda-Term.
  *)
+open LTerm_geom
 
 let ( >>= ) = Lwt.( >>= )
 
@@ -35,7 +36,10 @@ let main () =
   let top_frame = frame top_editor in
 
   (* make bottom editor a fixed 10 rows in size *)
-  let bottom_editor = new LTerm_edit.edit ~size:{ LTerm_geom.rows = 10; cols = 1 } () in
+  let bottom_editor = new LTerm_edit.edit ~size:{ rows = 10; cols = 1 } () in
+  (* changed my mind: make it 5 rows smaller *)
+  bottom_editor#set_allocation
+    { bottom_editor#allocation with row1 = bottom_editor#allocation.row1 - 5 };
   let bottom_frame = frame bottom_editor in
 
   vbox#add top_frame;

--- a/examples/double_editor.ml
+++ b/examples/double_editor.ml
@@ -43,7 +43,7 @@ let main () =
   let bottom_frame = frame bottom_editor in
 
   vbox#add top_frame;
-  (* in versions before my fix this would either crash or make the bottom editor unusable *)
+  (* in versions before PR#42 this would either crash or make the bottom editor unusable *)
   vbox#add ~expand:false bottom_frame;
 
   (* exit on C-c *)

--- a/examples/double_editor.ml
+++ b/examples/double_editor.ml
@@ -1,0 +1,67 @@
+(*
+ * double_editor.ml
+ * ----------
+ * Copyright : (c) 2016, Fabian Bonk <fabian.bonk@bonkii.com>
+ * Licence   : BSD3
+ *
+ * This file is a part of Lambda-Term.
+ *)
+
+let ( >>= ) = Lwt.( >>= )
+
+(* helper functions *)
+let make_key ?(ctrl = false) ?(meta = false) ?(shift = false) c =
+  let code =
+    match c with
+    | `Char c -> LTerm_key.Char (CamomileLibrary.UChar.of_char c)
+    | `Other key -> key in
+  { LTerm_key.control = ctrl; meta; shift; code }
+
+let frame widget =
+  let frame = new LTerm_widget.frame in
+  frame#set widget;
+  frame
+
+let main () =
+  let waiter, wakener = Lwt.wait () in
+
+  let ctrl_c = [make_key ~ctrl:true @@ `Char 'c'] in
+  let tab = [make_key @@ `Other LTerm_key.Tab] in
+  let quit = [LTerm_edit.Custom (Lwt.wakeup wakener)] in
+
+  let vbox = new LTerm_widget.vbox in
+
+  let top_editor = new LTerm_edit.edit () in
+  let top_frame = frame top_editor in
+
+  (* make bottom editor a fixed 10 rows in size *)
+  let bottom_editor = new LTerm_edit.edit ~size:{ LTerm_geom.rows = 10; cols = 1 } () in
+  let bottom_frame = frame bottom_editor in
+
+  vbox#add top_frame;
+  (* in versions before my fix this would either crash or make the bottom editor unusable *)
+  vbox#add ~expand:false bottom_frame;
+
+  (* exit on C-c *)
+  top_editor#bind ctrl_c quit;
+  bottom_editor#bind ctrl_c quit;
+
+  let send_key key =
+    LTerm_edit.Custom (fun () -> vbox#send_event @@ LTerm_event.Key (make_key key)) in
+
+  (* switch editors on Tab *)
+  top_editor#bind tab [send_key @@ `Other LTerm_key.Down];
+  bottom_editor#bind tab [send_key @@ `Other LTerm_key.Up];
+
+  let label = new LTerm_widget.label "Press Tab to switch between editors.\nPress C-c to exit." in
+  vbox#add ~expand:false label;
+
+  Lazy.force LTerm.stdout
+  >>= fun term ->
+  LTerm.enable_mouse term
+  >>= fun () ->
+  Lwt.finalize
+    (fun () -> LTerm_widget.run term ~save_state:false ~load_resources:false vbox waiter)
+    (fun () -> LTerm.disable_mouse term)
+
+let () = Lwt_main.run (main ())

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -217,6 +217,8 @@ object(self)
   val mutable start = 0
   val mutable start_line = 0
   val mutable size = size
+  
+  method! size_request = size
 
   method private update_window_position = 
     let line_set = Zed_edit.lines engine in

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -169,7 +169,7 @@ class scrollable = object(self)
   method calculate_range page_size document_size = (document_size - page_size/2)
 end
 
-class edit ?(clipboard = clipboard) ?(macro = macro) () =
+class edit ?(clipboard = clipboard) ?(macro = macro) ?(size = { cols = 1; rows = 1 }) () =
   let locale, set_locale = S.create None in
 object(self)
   inherit LTerm_widget.t "edit" as super
@@ -216,7 +216,7 @@ object(self)
   val mutable shift = 0
   val mutable start = 0
   val mutable start_line = 0
-  val mutable size = { cols = 0; rows = 0 }
+  val mutable size = size
 
   method private update_window_position = 
     let line_set = Zed_edit.lines engine in

--- a/src/lTerm_edit.mli
+++ b/src/lTerm_edit.mli
@@ -68,7 +68,10 @@ val macro : action Zed_macro.t
 
 (** Class of edition widgets. If no clipboard is provided, then the
     global one is used. *)
-class edit : ?clipboard : Zed_edit.clipboard -> ?macro : action Zed_macro.t -> unit -> object
+class edit :
+  ?clipboard : Zed_edit.clipboard ->
+  ?macro : action Zed_macro.t ->
+  ?size : LTerm_geom.size -> unit -> object
   inherit LTerm_widget.t
 
   method engine : edit Zed_edit.t


### PR DESCRIPTION
This PR is my attempt at fixing what I think might be a bug: Creating an `edit` widget with a non-default size or changing the size later via `set_allocation` does not work, since `size_request` only returns the default value. Overriding `size_request` fixes this.

This bug only came up because I wanted to add this feature: The ability to specify an initial size for the edit widget. I also chose some (in my opinion) more sane defaults: `{ rows = 1; cols = 1 }`. Having them be `0` makes the editor unusable when adding it to a `LTerm_widget.box` with `~expand:false` and even crashes the program if overridden manually. I made the argument optional to not break compatibility with existing programs.

Lastly I added an example program to both demonstrate using the new functionality as well as demonstrate how to switch between multiple `edit` widgets (something I could only figure out after trial-and-error for an hour).