### PR TITLE
Add clear method to LTerm_widget.box

### DIFF
--- a/src/lTerm_widget.mli
+++ b/src/lTerm_widget.mli
@@ -128,6 +128,9 @@ class type box = object
 
   method remove : #t -> unit
     (** [remove widget] remove a widget from the box. *)
+
+  method clear : unit
+    (** [clear] removes all widgets from the box. *)
 end
 
 (** A widget displaying a list of widgets, listed horizontally. *)

--- a/src/widget_impl/lTerm_containers_impl.ml
+++ b/src/widget_impl/lTerm_containers_impl.ml
@@ -26,6 +26,7 @@ class type box = object
   inherit t
   method add : ?position : int -> ?expand : bool -> #t -> unit
   method remove : #t -> unit
+  method clear : unit
 end
 
 class virtual abox rc = object(self)
@@ -65,6 +66,13 @@ class virtual abox rc = object(self)
 
   method remove : 'a. (#t as 'a) -> unit = fun widget ->
     children <- List.filter (fun child -> if child.widget = (widget :> t) then (child.widget#set_parent None; false) else true) children;
+    self#compute_size_request;
+    self#compute_allocations;
+    self#queue_draw
+
+  method clear =
+    List.iter (fun child -> child.widget#set_parent None) children;
+    children <- [];
     self#compute_size_request;
     self#compute_allocations;
     self#queue_draw


### PR DESCRIPTION
This PR adds a method to clear all widgets from a `LTerm_widget.box`.

Writing `some_box#clear` is easier and faster than writing
```
List.iter (fun child -> some_box#remove child) some_box#children
```
since the box only needs to be redrawn once.

I also updated my example from PR#42 to demonstrate the usage, although I'm not sure if there's any point in doing so; it's fairly self-explanatory and using `#clear` in this case isn't even the fastest way to do it (see the comment in `double_editor.ml`).