### PR TITLE
Add '^' to the list of characters.

### DIFF
--- a/src/lTerm_inputrc.mll
+++ b/src/lTerm_inputrc.mll
@@ -283,7 +283,7 @@ and sequence key seq = parse
         else
           sequence dummy_key seq lexbuf
       }
-  | [ 'a'-'z' 'A'-'Z' '0'-'9' '_' '(' ')' '[' ']' '{' '}' '~' '&' '$' '*' '%' '!' '?' ',' ';' '/' '\\' '.' '@' '=' '+' '-' ] as ch (blank+ | ':' as sep)
+  | [ 'a'-'z' 'A'-'Z' '0'-'9' '_' '(' ')' '[' ']' '{' '}' '~' '&' '$' '*' '%' '!' '?' ',' ';' '/' '\\' '.' '@' '=' '+' '-' '^' ] as ch (blank+ | ':' as sep)
       {
         let seq = { key with code = Char(UChar.of_char ch) } :: seq in
         if sep = ":" then


### PR DESCRIPTION
I am guessing '^' was just forgotten?

The omission is unfortunate, because C-^ is in C0 set, so one would expect to be able to bind it easily.

I compiled my copy of lambda-term-1.10.1 with this patch applied: nothing broke, AFAICS, and I am now able to bind C-^ in my ~/.lambda-term-inputrc (without this patch, I was getting "parsing error in key sequence").