### PR TITLE
Update to lwt.3.0.0

### DIFF
--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -10,8 +10,8 @@ build: [
   ["jbuilder" "build" "@install" "--root" "." "--only" "lambda-term" "-j" jobs]
 ]
 depends: [
-  "lwt"   {>= "2.4.0"}
+  "lwt"   {>= "3.0.0"}
   "zed"   {>= "1.2"}
-  "react" {>= "1.0.0"}
+  "lwt_react" {>= "1.0.0"}
 ]
 available: [ ocaml-version >= "4.02.3" ]

--- a/src/jbuild
+++ b/src/jbuild
@@ -26,7 +26,7 @@ let () =
  ((name lambda_term)
   (public_name lambda-term)
   (wrapped false)
-  (libraries (lwt lwt.unix lwt.react zed))
+  (libraries (lwt lwt.unix lwt_react zed))
   (synopsis "Cross-platform library for terminal manipulation")
   (c_names (lTerm_term_stubs lTerm_unix_stubs lTerm_windows_stubs))
   %s))


### PR DESCRIPTION
Note that lwt.react has been renamed to lwt_react in both opam and findlib:

  https://github.com/ocsigen/lwt/issues/308

Signed-off-by: David Scott <dave@recoil.org>