### PR TITLE
Erase the completion bar using escape codes instead of spaces on Unix

### DIFF
--- a/src/lTerm_draw.ml
+++ b/src/lTerm_draw.ml
@@ -26,14 +26,14 @@ type point = {
 
 type matrix = point array array
 
-let make_matrix size =
+let make_matrix ?(init=UChar.of_char ' ') size =
   Array.init
     size.rows
     (fun _ ->
        Array.init
          size.cols
          (fun _ -> {
-            char = UChar.of_char ' ';
+            char = init;
             bold = false;
             underline = false;
             blink = false;

--- a/src/lTerm_draw.mli
+++ b/src/lTerm_draw.mli
@@ -35,9 +35,9 @@ type matrix = point array array
         then columns, i.e. to access the point at line [l] and column
         [c] in matrix [m] you should use [m.(l).(c)]. *)
 
-val make_matrix : LTerm_geom.size -> matrix
-  (** [matrix size] creates a matrix of the given size containing only
-      blank characters. *)
+val make_matrix : ?init : UChar.t -> LTerm_geom.size -> matrix
+  (** [matrix ~init size] creates a matrix of the given size containing only
+      [init] (default: UChar.of_char ' ') characters. *)
 
 val set_style : point -> LTerm_style.t -> unit
   (** [set_style point style] sets fields of [point] according to

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -1079,7 +1079,10 @@ object(self)
       let pos_after_styled = compute_position size.cols pos_after_before styled position (Array.length styled) in
       let total_height = pos_after_styled.row + 1 in
       let matrix_size = { cols = size.cols + 1; rows = if displayed then max total_height height else total_height } in
-      let matrix = LTerm_draw.make_matrix matrix_size in
+      (* Note that the LTerm.print_box_with_newlines call below erases all the
+         positions after the first newline character in a row of matrix with
+         the "Erase in Line" escape code (on Unix) or spaces (on Windows). *)
+      let matrix = LTerm_draw.make_matrix ~init:newline matrix_size in
       draw_styled_with_newlines matrix size.cols 0 0 prompt;
       draw_styled_with_newlines matrix size.cols pos_after_prompt.row pos_after_prompt.col styled;
       draw_styled_with_newlines matrix size.cols pos_after_styled.row pos_after_styled.col styled_newline;


### PR DESCRIPTION
This resolves diml/utop#186 without large code changes by making a matrix filled with newlines instead of spaces. Note that `LTerm.print_box_with_newlines` erases all the positions after the first newline character in a row of a matrix with the "Erase in Line" escape code (on Unix) or spaces (on Windows).