### PR TITLE
Add camomile dep to lambda term

### DIFF
--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -12,6 +12,7 @@ build: [
 depends: [
   "lwt"   {>= "2.7.0"}
   "zed"   {>= "1.2"}
+  "camomile"
   "lwt_react"
   "jbuilder" {build & >= "1.0+beta7"}
 ]


### PR DESCRIPTION
Right now it's being pulled transitively from zed, but it's being used directly
in lambda-term