### PR TITLE
[WIP] Make lambda-term compatible with lwt 4.0.0

### DIFF
--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open Lwt
 
 let main () =

--- a/examples/read_yes_no.ml
+++ b/examples/read_yes_no.ml
@@ -11,7 +11,7 @@ open Lwt
 
 let rec read_char term =
   LTerm.read_event term >>= function
-    | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch; LTerm_key.control = true ; _ } when ch = CamomileLibraryDyn.Camomile.UChar.of_char 'c' ->
+    | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch; LTerm_key.control = true ; _ } when ch = CamomileLibraryDefault.Camomile.UChar.of_char 'c' ->
         (* Exit on Ctrl+C *)
         Lwt.fail (Failure "interrupted")
     | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch ; _ } ->

--- a/examples/shell.ml
+++ b/examples/shell.ml
@@ -9,7 +9,7 @@
 
 (* A mini shell *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open React
 open Lwt
 open LTerm_style

--- a/src/jbuild
+++ b/src/jbuild
@@ -4,7 +4,7 @@
  ((name lambda_term)
   (public_name lambda-term)
   (wrapped false)
-  (libraries (lwt lwt.unix lwt_react zed))
+  (libraries (lwt lwt.unix lwt_log lwt_react zed))
   (flags (:standard -safe-string))
   (synopsis "Cross-platform library for terminal manipulation")
   (c_names (lTerm_term_stubs lTerm_unix_stubs lTerm_windows_stubs))

--- a/src/lTerm.ml
+++ b/src/lTerm.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_geom
 

--- a/src/lTerm_buttons_impl.ml
+++ b/src/lTerm_buttons_impl.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open LTerm_geom
 open LTerm_key
 open LTerm_mouse
@@ -76,7 +76,7 @@ class button ?(brackets=("< "," >")) initial_label =
     let { rows; cols } = LTerm_draw.size ctx in
     let len = Zed_utf8.length label in
     self#apply_style ctx focused;
-    LTerm_draw.draw_string ctx (rows / 2) ((cols - len - brackets_size) / 2) 
+    LTerm_draw.draw_string ctx (rows / 2) ((cols - len - brackets_size) / 2)
       (Printf.sprintf "%s%s%s" bl label br)
 end
 
@@ -87,17 +87,17 @@ class checkbutton initial_label initial_state = object(self)
 
   initializer
     self#on_event (fun ev ->
-      let update () = 
+      let update () =
         state <- not state;
         (* checkbutton changes the state when clicked, so has to be redrawn *)
         self#queue_draw;
         exec_callbacks click_callbacks ();
         true
       in
-      match ev with 
+      match ev with
         | LTerm_event.Key { control = false; meta = false; shift = false; code }
           when (code = Enter || code = space) -> update ()
-        | LTerm_event.Mouse m 
+        | LTerm_event.Mouse m
           when m.button = Button1 -> update ()
         | _ ->
             false);
@@ -157,7 +157,7 @@ class ['a] radiobutton (group : 'a radiogroup) initial_label (id : 'a) = object(
   initializer
     self#on_event
     (fun ev ->
-      let update () = 
+      let update () =
         if state
         (* no need to do anything if the button is on already *)
         then ()

--- a/src/lTerm_draw.ml
+++ b/src/lTerm_draw.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open LTerm_geom
 
 let unsafe_get matrix line column =
@@ -118,9 +118,9 @@ let sub_opt ctx rect =
     if row2 > ctx.ctx_row2 || col2 > ctx.ctx_col2 then None
     else Some { ctx with ctx_row1 = row1; ctx_col1 = col1; ctx_row2 = row2; ctx_col2 = col2 }
 
-let sub ctx rect = 
-  match sub_opt ctx rect with 
-  | None -> raise Out_of_bounds 
+let sub ctx rect =
+  match sub_opt ctx rect with
+  | None -> raise Out_of_bounds
   | Some(ctx) -> ctx
 
 let space = UChar.of_char ' '
@@ -592,7 +592,7 @@ let draw_frame ctx rect ?style connection =
   draw_piece ctx (rect.row2 - 1) (rect.col2 - 1) ?style { top = connection; bottom = Blank; left = connection; right = Blank };
   draw_piece ctx (rect.row2 - 1) (rect.col1 + 0) ?style { top = connection; bottom = Blank; left = Blank; right = connection }
 
-let draw_frame_labelled ctx rect ?style ?(alignment=H_align_left) label connection = 
+let draw_frame_labelled ctx rect ?style ?(alignment=H_align_left) label connection =
   draw_frame ctx rect ?style connection;
   let rect = { row1 = rect.row1; row2 = rect.row1+1; col1 = rect.col1+1; col2 = rect.col2-1 } in
   match sub_opt ctx rect with

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open Zed_edit
 open LTerm_key
 open LTerm_geom
@@ -217,10 +217,10 @@ object(self)
   val mutable start = 0
   val mutable start_line = 0
   val mutable size = size
-  
+
   method! size_request = size
 
-  method private update_window_position = 
+  method private update_window_position =
     let line_set = Zed_edit.lines engine in
     let line_count = Zed_lines.count line_set in
     let cursor_offset = Zed_cursor.get_position cursor in
@@ -266,7 +266,7 @@ object(self)
     cursor <- Zed_edit.new_cursor engine;
     context <- Zed_edit.context engine cursor;
     Zed_edit.set_data engine (self :> edit);
-    event <- E.map (fun _ -> 
+    event <- E.map (fun _ ->
       self#update_window_position;
       self#queue_draw) (Zed_edit.update engine [cursor]);
     self#on_event
@@ -341,8 +341,8 @@ object(self)
     start <- 0; shift <- 0; start_line <- 0;
     self#update_window_position
 
-  initializer vscroll#on_offset_change (fun n -> 
- 
+  initializer vscroll#on_offset_change (fun n ->
+
     (* find what line the cursor is currently on. *)
     let line_set = Zed_edit.lines engine in
     let cursor_offset = Zed_cursor.get_position cursor in
@@ -350,7 +350,7 @@ object(self)
 
     start_line <- n;
     start <- Zed_lines.line_start line_set start_line;
-    
+
     if cursor_line < start_line then begin
       let d = start_line - cursor_line in
       Zed_edit.move_line context d (* first row *)

--- a/src/lTerm_history.ml
+++ b/src/lTerm_history.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 
 let return, (>>=) = Lwt.return, Lwt.(>>=)
 

--- a/src/lTerm_inputrc.mll
+++ b/src/lTerm_inputrc.mll
@@ -8,7 +8,7 @@
  *)
 
 {
-  open CamomileLibraryDyn.Camomile
+  open CamomileLibraryDefault.Camomile
   open LTerm_key
 
   let return, (>>=) = Lwt.return, Lwt.(>>=)

--- a/src/lTerm_key.ml
+++ b/src/lTerm_key.ml
@@ -14,7 +14,7 @@ module String = struct
   include String
 end
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 
 type code =
   | Char of UChar.t

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_geom
 open LTerm_style

--- a/src/lTerm_text.ml
+++ b/src/lTerm_text.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open LTerm_style
 
 type t = (UChar.t * LTerm_style.t) array

--- a/src/lTerm_unix.ml
+++ b/src/lTerm_unix.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open LTerm_key
 
 let return, (>>=), (>|=) = Lwt.return, Lwt.(>>=), Lwt.(>|=)

--- a/src/lTerm_unix.mli
+++ b/src/lTerm_unix.mli
@@ -9,7 +9,7 @@
 
 (** Unix specific functions *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 
 val sigwinch : int option
   (** The number of the signal used to indicate that the terminal size

--- a/src/lTerm_widget.ml
+++ b/src/lTerm_widget.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 open LTerm_geom
 open LTerm_draw
 
@@ -155,7 +155,7 @@ class type scrollable_adjustment = object
   method set_mouse_mode : [ `middle | `ratio | `auto ] -> unit
   method set_min_scroll_bar_size : int -> unit
   method set_max_scroll_bar_size : int -> unit
-  method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch -> 
+  method on_scrollbar_change : ?switch:LTerm_widget_callbacks.switch ->
     (unit -> unit) -> unit
 end
 

--- a/src/lTerm_windows.ml
+++ b/src/lTerm_windows.ml
@@ -7,7 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDyn.Camomile
+open CamomileLibraryDefault.Camomile
 
 let (>|=) = Lwt.(>|=)
 


### PR DESCRIPTION
[WIP] pull request to fix #60. It doesn't build yet. Will remove the [WIP] label once we lambda-term builds and runs successfully with lwt 4.0.0. Outstanding issues.

- [x] Migrate to camomile 1.0.0
- [ ] Migrate ```Lwt_sequence```. Also see PR #61. Status - In progress. We need some resolution/help from lwt guys possibly. See https://github.com/ocsigen/lwt/issues/573
- [ ] If possible migrate ```Lwt_unix.execute_job``` to be replaced with ```Lwt_unix.run_job```. 